### PR TITLE
@W-8913847 - Simplifying createTempDirectory.

### DIFF
--- a/src/common/CommonUtils.ts
+++ b/src/common/CommonUtils.ts
@@ -4,10 +4,13 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { Logger } from '@salesforce/core';
+import { Logger, SfdxError } from '@salesforce/core';
 import * as childProcess from 'child_process';
 import { cli } from 'cli-ux';
 import fs from 'fs';
+import util from 'util';
+import path from 'path';
+import os from 'os';
 
 type StdioOptions = childProcess.StdioOptions;
 
@@ -69,6 +72,28 @@ export class CommonUtils {
             }
             return variables[key];
         });
+    }
+
+    public static async createTempDirectory(): Promise<string> {
+        const mkdtemp = util.promisify(fs.mkdtemp);
+        const folderPrefix = 'lwc-mobile-';
+        const tempFolderPath = path.join(os.tmpdir(), folderPrefix);
+        return mkdtemp(tempFolderPath)
+            .then((folder) => {
+                return Promise.resolve(folder);
+            })
+            .catch((error) => {
+                return Promise.reject(
+                    new SfdxError(
+                        util.format(
+                            'Could not create a temp folder at %s: %s',
+                            tempFolderPath,
+                            error
+                        ),
+                        'lwc-dev-mobile-core'
+                    )
+                );
+            });
     }
 
     public static executeCommandSync(

--- a/src/common/CommonUtils.ts
+++ b/src/common/CommonUtils.ts
@@ -4,13 +4,10 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { Logger, SfdxError } from '@salesforce/core';
+import { Logger } from '@salesforce/core';
 import * as childProcess from 'child_process';
 import { cli } from 'cli-ux';
 import fs from 'fs';
-import os from 'os';
-import path from 'path';
-import util from 'util';
 
 type StdioOptions = childProcess.StdioOptions;
 
@@ -72,29 +69,6 @@ export class CommonUtils {
             }
             return variables[key];
         });
-    }
-
-    public static async createTempDirectory(
-        subfolder: string = ''
-    ): Promise<string> {
-        const mkdtemp = util.promisify(fs.mkdtemp);
-        const tempFolderPath = path.join(os.tmpdir(), subfolder);
-        return mkdtemp(tempFolderPath)
-            .then((folder) => {
-                return Promise.resolve(folder);
-            })
-            .catch((error) => {
-                return Promise.reject(
-                    new SfdxError(
-                        util.format(
-                            'Could not create a temp folder at %s: %s',
-                            tempFolderPath,
-                            error
-                        ),
-                        'lwc-dev-mobile-core'
-                    )
-                );
-            });
     }
 
     public static executeCommandSync(

--- a/src/common/__tests__/CommonUtils.test.ts
+++ b/src/common/__tests__/CommonUtils.test.ts
@@ -5,8 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { CommonUtils } from '../CommonUtils';
-import os from 'os';
-import fs from 'fs';
 
 describe('CommonUtils', () => {
     test('replaceTokens function', async () => {
@@ -25,29 +23,5 @@ describe('CommonUtils', () => {
             // tslint:disable-next-line:no-invalid-template-strings
             'A quick brown ${animal1} jumped over the lazy ${animal2}'
         );
-    });
-
-    test('createTempDirectory function', async () => {
-        const tmpDir = os.tmpdir();
-
-        let folder = await CommonUtils.createTempDirectory();
-        expect(fs.existsSync(folder)).toBeTruthy();
-        expect(folder.includes(tmpDir)).toBeTruthy();
-
-        folder = await CommonUtils.createTempDirectory('');
-        expect(fs.existsSync(folder)).toBeTruthy();
-        expect(folder.includes(tmpDir)).toBeTruthy();
-
-        const errorMessage = 'Error creating a temp folder';
-        jest.spyOn(fs, 'mkdtemp').mockImplementationOnce((_, callback) =>
-            callback(new Error(errorMessage), '')
-        );
-
-        try {
-            await CommonUtils.createTempDirectory();
-        } catch (error) {
-            const message = `Could not create a temp folder at ${tmpDir}: `;
-            expect(error.message.includes(message)).toBeTruthy();
-        }
     });
 });

--- a/src/common/__tests__/CommonUtils.test.ts
+++ b/src/common/__tests__/CommonUtils.test.ts
@@ -5,6 +5,9 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { CommonUtils } from '../CommonUtils';
+import os from 'os';
+import fs from 'fs';
+import path from 'path';
 
 describe('CommonUtils', () => {
     test('replaceTokens function', async () => {
@@ -23,5 +26,26 @@ describe('CommonUtils', () => {
             // tslint:disable-next-line:no-invalid-template-strings
             'A quick brown ${animal1} jumped over the lazy ${animal2}'
         );
+    });
+
+    test('createTempDirectory function', async () => {
+        const tmpDir = os.tmpdir();
+        const folderPrefix = 'lwc-mobile-';
+        const tempFolderPath = path.join(tmpDir, folderPrefix);
+
+        const folder = await CommonUtils.createTempDirectory();
+        expect(fs.existsSync(folder)).toBeTruthy();
+        expect(folder.includes(tempFolderPath)).toBeTruthy();
+
+        jest.spyOn(fs, 'mkdtemp').mockImplementationOnce((_, callback) =>
+            callback(new Error(), '')
+        );
+
+        try {
+            await CommonUtils.createTempDirectory();
+        } catch (error) {
+            const message = `Could not create a temp folder at ${tempFolderPath}: `;
+            expect(error.message.includes(message)).toBeTruthy();
+        }
     });
 });


### PR DESCRIPTION
`createTempDirectory` will no longer take user input for subfolder. Instead, it will use prefix that will be combined with random string of characters provided by `mkdtmp()`.