### PR TITLE
Return API packages with emulator images

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/lwc-dev-mobile-core",
-  "description": "Salesforce CLI plugin for mobile extensions to Local Development",
-  "version": "1.0.0-beta1",
+  "description": "Core module supporting Salesforce CLI mobile extension plug-ins",
+  "version": "1.0.0-beta2",
   "author": {
     "name": "Meisam Seyed Aliroteh",
     "email": "maliroteh@salesforce.com",

--- a/src/common/AndroidEnvironmentSetup.ts
+++ b/src/common/AndroidEnvironmentSetup.ts
@@ -207,7 +207,7 @@ export class PlatformAPIPackageRequirement implements Requirement {
     }
 
     public async checkFunction(): Promise<string> {
-        return AndroidUtils.findRequiredAndroidAPIPackage(this.apiLevel)
+        return AndroidUtils.fetchSupportedAndroidAPIPackage(this.apiLevel)
             .then((result) =>
                 Promise.resolve(
                     util.format(this.fulfilledMessage, result.platformAPI)
@@ -245,7 +245,7 @@ export class EmulatorImagesRequirement implements Requirement {
     }
 
     public async checkFunction(): Promise<string> {
-        return AndroidUtils.findRequiredEmulatorImages(this.apiLevel)
+        return AndroidUtils.fetchSupportedEmulatorImagePackage(this.apiLevel)
             .then((result) =>
                 Promise.resolve(util.format(this.fulfilledMessage, result.path))
             )

--- a/src/common/AndroidLauncher.ts
+++ b/src/common/AndroidLauncher.ts
@@ -24,7 +24,7 @@ export class AndroidLauncher {
         appConfig: AndroidAppPreviewConfig | undefined,
         serverPort: string
     ): Promise<void> {
-        const preferredPack = await AndroidUtils.findRequiredEmulatorImages();
+        const preferredPack = await AndroidUtils.fetchSupportedEmulatorImagePackage();
         const emuImage = preferredPack.platformEmulatorImage || 'default';
         const androidApi = preferredPack.platformAPI;
         const abi = preferredPack.abi;
@@ -66,7 +66,7 @@ export class AndroidLauncher {
                     `Launching`,
                     `Waiting for device ${emuName} to boot`
                 );
-                return AndroidUtils.pollDeviceStatus(emulatorPort);
+                return AndroidUtils.waitUntilDeviceIsReady(emulatorPort);
             })
             .then(() => {
                 const useServer = PreviewUtils.useLwcServerForPreviewing(

--- a/src/common/__tests__/AndroidEnvironmentSetup.test.ts
+++ b/src/common/__tests__/AndroidEnvironmentSetup.test.ts
@@ -152,7 +152,7 @@ describe('Android enviroment setup tests', () => {
     test('Should resolve when required platform API packages are present', async () => {
         jest.spyOn(
             AndroidUtils,
-            'findRequiredAndroidAPIPackage'
+            'fetchSupportedAndroidAPIPackage'
         ).mockImplementation(() =>
             Promise.resolve(
                 new AndroidPackage('', new Version(0, 0, 0), '', '')
@@ -169,7 +169,7 @@ describe('Android enviroment setup tests', () => {
     test('Should reject when required platform API packages are not present', async () => {
         jest.spyOn(
             AndroidUtils,
-            'findRequiredAndroidAPIPackage'
+            'fetchSupportedAndroidAPIPackage'
         ).mockImplementation(() => Promise.reject(''));
         const requirement = new PlatformAPIPackageRequirement(
             androidEnvironment.setupMessages,
@@ -182,7 +182,7 @@ describe('Android enviroment setup tests', () => {
     test('Should resolve when required emulator images are available', async () => {
         jest.spyOn(
             AndroidUtils,
-            'findRequiredEmulatorImages'
+            'fetchSupportedEmulatorImagePackage'
         ).mockImplementation(() =>
             Promise.resolve(
                 new AndroidPackage('', new Version(0, 0, 0), '', '')
@@ -199,7 +199,7 @@ describe('Android enviroment setup tests', () => {
     test('Should reject when Java 8 is not available', async () => {
         jest.spyOn(
             AndroidUtils,
-            'findRequiredEmulatorImages'
+            'fetchSupportedEmulatorImagePackage'
         ).mockImplementation(() => Promise.reject(''));
         const requirement = new EmulatorImagesRequirement(
             androidEnvironment.setupMessages,

--- a/src/common/__tests__/AndroidUtils.test.ts
+++ b/src/common/__tests__/AndroidUtils.test.ts
@@ -219,7 +219,7 @@ describe('Android utils', () => {
         jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myCommandBlockMock
         );
-        const apiPackage = await AndroidUtils.findRequiredAndroidAPIPackage();
+        const apiPackage = await AndroidUtils.fetchSupportedAndroidAPIPackage();
         expect(apiPackage !== null && apiPackage.description !== null).toBe(
             true
         );
@@ -229,7 +229,7 @@ describe('Android utils', () => {
         jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myCommandBlockMock
         );
-        const apiPackage = await AndroidUtils.findRequiredAndroidAPIPackage(
+        const apiPackage = await AndroidUtils.fetchSupportedAndroidAPIPackage(
             '28'
         );
         expect(apiPackage !== null && apiPackage.description !== null).toBe(
@@ -242,7 +242,7 @@ describe('Android utils', () => {
         jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             badBlockMock
         );
-        AndroidUtils.findRequiredAndroidAPIPackage().catch((error) => {
+        AndroidUtils.fetchSupportedAndroidAPIPackage().catch((error) => {
             expect(error).toBeTruthy();
         });
     });
@@ -251,7 +251,7 @@ describe('Android utils', () => {
         jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myCommandBlockMock
         );
-        const apiPackage = await AndroidUtils.findRequiredEmulatorImages();
+        const apiPackage = await AndroidUtils.fetchSupportedEmulatorImagePackage();
         expect(apiPackage !== null && apiPackage.description !== null).toBe(
             true
         );
@@ -261,7 +261,7 @@ describe('Android utils', () => {
         jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             badBlockMock
         );
-        AndroidUtils.findRequiredEmulatorImages().catch((error) => {
+        AndroidUtils.fetchSupportedEmulatorImagePackage().catch((error) => {
             expect(error).toBeTruthy();
         });
     });


### PR DESCRIPTION
1. Updated `AndroidUtils.fetchAllAvailableApiPackages` to optionally only return those packages for which matching emulator images are installed.
2. Added comments to all public functions in `AndroidUtils`
3. Renamed `AndroidUtils.pollDeviceStatus` to `AndroidUtils.waitUntilDeviceIsReady` to match its iOS counterpart.
4. Renamed all instances of `find` and `required` in `AndroidUtils` function names to `fetch` and `supported` for consistency.
5. A few other renaming for the sake of consistency