### PR TITLE
change logic to detect when AVD is booted

### DIFF
--- a/messages/setup.json
+++ b/messages/setup.json
@@ -37,9 +37,5 @@
     "android:reqs:platformapi:unfulfilledMessage" : "No supported Android API package found. Minimum supported Android API package version is %s.",
     "android:reqs:emulatorimages:title" : "Checking SDK Platform Emulator Images",
     "android:reqs:emulatorimages:fulfilledMessage" : "Android emulator image (%s) was detected.",
-    "android:reqs:emulatorimages:unfulfilledMessage" : "Install at least one of these emulator images: %s",
-
-    "common:reqs:serverplugin:title" : "Checking @salesforce/lwc-dev-server plugin",
-    "common:reqs:serverplugin:fulfilledMessage" : "@salesforce/lwc-dev-server plugin is installed.",
-    "common:reqs:serverplugin:unfulfilledMessage" : "Install the @salesforce/lwc-dev-server plugin."
+    "android:reqs:emulatorimages:unfulfilledMessage" : "Install at least one of these emulator images: %s"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/lwc-dev-mobile-core",
   "description": "Core module supporting Salesforce CLI mobile extension plug-ins",
-  "version": "1.0.0-beta2",
+  "version": "1.0.0-beta3",
   "author": {
     "name": "Meisam Seyed Aliroteh",
     "email": "maliroteh@salesforce.com",

--- a/src/common/AndroidUtils.ts
+++ b/src/common/AndroidUtils.ts
@@ -457,9 +457,8 @@ export class AndroidUtils {
                             )
                         );
                     });
-                    child.stderr.on('data', (data) => {
-                        const msg = data.toString() as string;
-                        if (msg && msg.includes('Error:')) {
+                    child.stderr.on('data', (data: Buffer) => {
+                        if (data.includes('Error:')) {
                             reject(
                                 new Error(
                                     `Could not create emulator. Command failed: ${createAvdCommand}\n${data}`

--- a/src/common/CommonUtils.ts
+++ b/src/common/CommonUtils.ts
@@ -24,6 +24,23 @@ export class CommonUtils {
         return Promise.resolve();
     }
 
+    public static promiseWithTimeout<T>(
+        timeout: number,
+        promise: Promise<T>,
+        failureMessage?: string
+    ): Promise<T> {
+        let timeoutHandle: NodeJS.Timeout;
+        const timeoutPromise = new Promise<never>((resolve, reject) => {
+            timeoutHandle = setTimeout(() => {
+                reject(new Error(failureMessage));
+            }, timeout);
+        });
+
+        return Promise.race([promise, timeoutPromise]).finally(() => {
+            clearTimeout(timeoutHandle);
+        });
+    }
+
     public static async delay(ms: number): Promise<void> {
         return new Promise((resolve) => setTimeout(resolve, ms));
     }

--- a/src/common/CommonUtils.ts
+++ b/src/common/CommonUtils.ts
@@ -29,6 +29,11 @@ export class CommonUtils {
         promise: Promise<T>,
         failureMessage?: string
     ): Promise<T> {
+        // Javascript/TypeScript do not have promises that timeout. However we could use
+        // Promise.race() to easily implement that. Promise.race() executes two promises
+        // and returns as soon as one of them resolves/rejects without waiting for the other.
+        // So we can take the user provided promise and race it against another promise that we
+        // create, which simply sleeps for a set amount of time then rejects with timeout error.
         let timeoutHandle: NodeJS.Timeout;
         const timeoutPromise = new Promise<never>((resolve, reject) => {
             timeoutHandle = setTimeout(() => {
@@ -37,6 +42,8 @@ export class CommonUtils {
         });
 
         return Promise.race([promise, timeoutPromise]).finally(() => {
+            // Clear the timeout handle so that any attached debugger would not remain attached
+            // until after setTimeout() call returns.
             clearTimeout(timeoutHandle);
         });
     }

--- a/src/common/CommonUtils.ts
+++ b/src/common/CommonUtils.ts
@@ -19,11 +19,22 @@ const LOGGER_NAME = 'force:lightning:local:commonutils';
 export class CommonUtils {
     public static DEFAULT_LWC_SERVER_PORT = '3333';
 
+    /**
+     * Initializes the logger used by CommonUtils for logging activities.
+     */
     public static async initializeLogger(): Promise<void> {
         CommonUtils.logger = await Logger.child(LOGGER_NAME);
         return Promise.resolve();
     }
 
+    /**
+     * Returns a Promise that supports timeout
+     *
+     * @param timeout Timeout value in milliseconds.
+     * @param promise The promise to execute
+     * @param failureMessage Optional failure message when timeout happens
+     * @returns A Promise that supports timeout
+     */
     public static promiseWithTimeout<T>(
         timeout: number,
         promise: Promise<T>,
@@ -43,23 +54,47 @@ export class CommonUtils {
 
         return Promise.race([promise, timeoutPromise]).finally(() => {
             // Clear the timeout handle so that any attached debugger would not remain attached
-            // until after setTimeout() call returns.
+            // until after setTimeout() call returns. This is specially useful for large timeout values.
             clearTimeout(timeoutHandle);
         });
     }
 
+    /**
+     * Sleeps for a given amount of time.
+     *
+     * @param ms Sleep time in milliseconds.
+     * @returns A promise that simply sleeps for a given amount of time.
+     */
     public static async delay(ms: number): Promise<void> {
         return new Promise((resolve) => setTimeout(resolve, ms));
     }
 
+    /**
+     * Starts a CLI action
+     *
+     * @param action Title of the action.
+     * @param status Optional status message for the action.
+     */
     public static startCliAction(action: string, status?: string) {
         cli.action.start(action, status, { stdout: true });
     }
 
+    /**
+     * Stops a CLI action
+     *
+     * @param message Optional status message for the action.
+     */
     public static stopCliAction(message?: string) {
         cli.action.stop(message);
     }
 
+    /**
+     * Given a path it will attempt to replace the ~ character *at the beginning* of
+     * the path (if any) with the user's home path value.
+     *
+     * @param inputPath The path to resolve.
+     * @returns Resolved path.
+     */
     public static resolveUserHomePath(inputPath: string): string {
         let newPath = inputPath.trim();
         if (newPath.startsWith('~')) {
@@ -73,17 +108,29 @@ export class CommonUtils {
         return newPath;
     }
 
+    /**
+     * Given the path to a JSON file, it will load the content of the file.
+     *
+     * @param file The path to the JSON file.
+     * @returns Content of the file as JSON object.
+     */
     public static loadJsonFromFile(file: string): any {
         const fileContent = fs.readFileSync(file, 'utf8');
         const json = JSON.parse(fileContent);
         return json;
     }
 
-    // Replace instances of '${value}' in a string with variables['value'].
-    // Example input:
-    // template: '${token}.my.salesforce.com'
-    // variables['token']: 'myHost'
-    // returns: 'myHost.my.salesforce.com'
+    /**
+     * Given a tokenized string, it replaces instances of variables in the tokenized string with their associated values.
+     * Example input:
+     * template: '${token}.my.salesforce.com'
+     * variables['token']: 'myHost'
+     * returns: 'myHost.my.salesforce.com'
+     *
+     * @param template Tokenized input string.
+     * @param variables List of token names and values.
+     * @returns Resolved string.
+     */
     public static replaceTokens(
         template: string,
         variables: { [name: string]: string }
@@ -98,6 +145,11 @@ export class CommonUtils {
         });
     }
 
+    /**
+     * Creates a unique temp directory that is prefixed with 'lwc-mobile-'
+     *
+     * @returns Path to the newaly created temp directory.
+     */
     public static async createTempDirectory(): Promise<string> {
         const mkdtemp = util.promisify(fs.mkdtemp);
         const folderPrefix = 'lwc-mobile-';
@@ -120,6 +172,13 @@ export class CommonUtils {
             });
     }
 
+    /**
+     * Execute a command synchronously and throws any errors that occur.
+     *
+     * @param command The command to be executed.
+     * @param stdioOptions Options to be used for [stderr, stdin, stdout]. Defaults to ['ignore', 'pipe', 'ignore']
+     * @returns Result of the command execution.
+     */
     public static executeCommandSync(
         command: string,
         stdioOptions: StdioOptions = ['ignore', 'pipe', 'ignore']
@@ -138,6 +197,12 @@ export class CommonUtils {
         }
     }
 
+    /**
+     * Execute a command asynchronously.
+     *
+     * @param command The command to be executed.
+     * @returns A promise containing the results of stdout and stderr
+     */
     public static async executeCommandAsync(
         command: string
     ): Promise<{ stdout: string; stderr: string }> {
@@ -169,6 +234,12 @@ export class CommonUtils {
         );
     }
 
+    /**
+     * A Promise that checks whether the local dev server plugin is installed or not.
+     * The Promise will resolve if the plugin is installed and will reject otherwise.
+     *
+     * @returns A Promise that checks whether the local dev server plugin is installed or not.
+     */
     public static async isLwcServerPluginInstalled(): Promise<void> {
         const command = 'sfdx force:lightning:lwc:start --help';
         return CommonUtils.executeCommandAsync(command).then(() =>
@@ -176,6 +247,11 @@ export class CommonUtils {
         );
     }
 
+    /**
+     * Gets the port number for local dev server.
+     *
+     * @returns The port that local dev server is running on, or undefined if the server is not running.
+     */
     public static async getLwcServerPort(): Promise<string | undefined> {
         const getProcessCommand =
             process.platform === 'win32'

--- a/src/common/PlatformConfig.ts
+++ b/src/common/PlatformConfig.ts
@@ -59,6 +59,5 @@ export class AndroidConfig {
     ];
     public readonly defaultEmulatorName: string = 'SFDXEmulator';
     public readonly defaultAdbPort: number = 5572;
-    public readonly deviceBootReadinessWaitTime: number = 10000;
-    public readonly deviceBootStatusPollRetries: number = 10;
+    public readonly deviceBootReadinessWaitTime: number = 120000;
 }

--- a/src/common/Requirements.ts
+++ b/src/common/Requirements.ts
@@ -113,12 +113,7 @@ export abstract class BaseSetup implements RequirementList {
 
     constructor(logger: Logger) {
         this.logger = logger;
-        this.requirements = [
-            new LWCServerPluginInstalledRequirement(
-                this.setupMessages,
-                this.logger
-            )
-        ];
+        this.requirements = [];
         this.additionalRequirements = [];
     }
 
@@ -237,55 +232,5 @@ export abstract class BaseSetup implements RequirementList {
 
     private formatDurationAsSeconds(duration: number): string {
         return `${duration.toFixed(3)} sec`;
-    }
-}
-
-// tslint:disable-next-line: max-classes-per-file
-export class LWCServerPluginInstalledRequirement implements Requirement {
-    public title: string;
-    public fulfilledMessage: string;
-    public unfulfilledMessage: string;
-    public logger: Logger;
-
-    constructor(messages: Messages, logger: Logger) {
-        this.title = messages.getMessage('common:reqs:serverplugin:title');
-        this.fulfilledMessage = messages.getMessage(
-            'common:reqs:serverplugin:fulfilledMessage'
-        );
-        this.unfulfilledMessage = messages.getMessage(
-            'common:reqs:serverplugin:unfulfilledMessage'
-        );
-        this.logger = logger;
-    }
-
-    public async checkFunction(): Promise<string> {
-        return CommonUtils.isLwcServerPluginInstalled()
-            .then(() => {
-                this.logger.info('sfdx server plugin detected.');
-                return Promise.resolve(this.fulfilledMessage);
-            })
-            .catch((error) => {
-                this.logger.info('sfdx server plugin was not detected.');
-
-                try {
-                    const command =
-                        'sfdx plugins:install @salesforce/lwc-dev-server';
-                    this.logger.info(
-                        `Installing sfdx server plugin.... ${command}`
-                    );
-                    CommonUtils.executeCommandSync(command, [
-                        'inherit',
-                        'pipe',
-                        'inherit'
-                    ]);
-                    this.logger.info('sfdx server plugin installed.');
-                    return Promise.resolve(this.fulfilledMessage);
-                } catch (error) {
-                    this.logger.error(
-                        `sfdx server plugin installion failed. ${error}`
-                    );
-                    return Promise.reject(new Error(this.unfulfilledMessage));
-                }
-            });
     }
 }

--- a/src/common/__tests__/Requirements.test.ts
+++ b/src/common/__tests__/Requirements.test.ts
@@ -5,20 +5,9 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { Logger } from '@salesforce/core';
-import {
-    BaseSetup,
-    LWCServerPluginInstalledRequirement
-} from '../Requirements';
+import { BaseSetup } from '../Requirements';
 
 const logger = new Logger('test');
-
-const passedBaseRequirementsMock = jest.fn(() => {
-    return Promise.resolve('sfdx server plugin is installed.');
-});
-
-const failedBaseRequirementsMock = jest.fn(() => {
-    return Promise.reject(new Error('sfdx server plugin is not installed.'));
-});
 
 class TruthyExtension extends BaseSetup {
     constructor() {
@@ -159,20 +148,12 @@ class AdditionalExtension extends BaseSetup {
 describe('Requirements Processing', () => {
     test('Meets all requirements', async () => {
         expect.assertions(1);
-        jest.spyOn(
-            LWCServerPluginInstalledRequirement.prototype,
-            'checkFunction'
-        ).mockImplementation(passedBaseRequirementsMock);
         const setupResult = await new TruthyExtension().executeSetup();
         expect(setupResult.hasMetAllRequirements).toBeTruthy();
     });
 
     test('Executes all true requirements', async () => {
         expect.assertions(1);
-        jest.spyOn(
-            LWCServerPluginInstalledRequirement.prototype,
-            'checkFunction'
-        ).mockImplementation(passedBaseRequirementsMock);
         const extension = new TruthyExtension();
         const setupResult = await extension.executeSetup();
         expect(
@@ -182,30 +163,18 @@ describe('Requirements Processing', () => {
 
     test('Executes all passed and failed requirements', async () => {
         expect.assertions(1);
-        jest.spyOn(
-            LWCServerPluginInstalledRequirement.prototype,
-            'checkFunction'
-        ).mockImplementation(passedBaseRequirementsMock);
         const setupResult = await new FalsyExtension().executeSetup();
         expect(setupResult.hasMetAllRequirements).toBeFalsy();
     });
 
     test('Executes all passed and failed base requirements', async () => {
         expect.assertions(1);
-        jest.spyOn(
-            LWCServerPluginInstalledRequirement.prototype,
-            'checkFunction'
-        ).mockImplementation(failedBaseRequirementsMock);
         const setupResult = await new TruthyExtension().executeSetup();
-        expect(setupResult.hasMetAllRequirements).toBeFalsy();
+        expect(setupResult.hasMetAllRequirements).toBeTruthy();
     });
 
     test('Executes all passed and failed requirements', async () => {
         expect.assertions(1);
-        jest.spyOn(
-            LWCServerPluginInstalledRequirement.prototype,
-            'checkFunction'
-        ).mockImplementation(passedBaseRequirementsMock);
         const extension = new TruthyExtension();
         const setupResult = await extension.executeSetup();
         expect(
@@ -215,10 +184,6 @@ describe('Requirements Processing', () => {
 
     test('Skips all base requirements and only executes all additional requirements', async () => {
         expect.assertions(1);
-        jest.spyOn(
-            LWCServerPluginInstalledRequirement.prototype,
-            'checkFunction'
-        ).mockImplementation(passedBaseRequirementsMock);
         const extension = new AdditionalExtension();
         extension.skipBaseRequirements = true;
         const setupResult = await extension.executeSetup();
@@ -227,10 +192,6 @@ describe('Requirements Processing', () => {
 
     test('Skips all base and additional requirements', async () => {
         expect.assertions(1);
-        jest.spyOn(
-            LWCServerPluginInstalledRequirement.prototype,
-            'checkFunction'
-        ).mockImplementation(passedBaseRequirementsMock);
         const extension = new AdditionalExtension();
         extension.skipBaseRequirements = true;
         extension.skipAdditionalRequirements = true;
@@ -240,10 +201,6 @@ describe('Requirements Processing', () => {
 
     test('There is only one test that failed with supplemental message', async () => {
         expect.assertions(2);
-        jest.spyOn(
-            LWCServerPluginInstalledRequirement.prototype,
-            'checkFunction'
-        ).mockImplementation(passedBaseRequirementsMock);
         const extension = new FalsyExtension();
         const setupResult = await extension.executeSetup();
         const testsResultWithMessages = setupResult.tests.filter(
@@ -258,10 +215,6 @@ describe('Requirements Processing', () => {
 
     test('There is only one test without any message', async () => {
         expect.assertions(2);
-        jest.spyOn(
-            LWCServerPluginInstalledRequirement.prototype,
-            'checkFunction'
-        ).mockImplementation(passedBaseRequirementsMock);
         const extension = new FalsyExtension();
         const setupResult = await extension.executeSetup();
         const testsResultWithoutMessages = setupResult.tests.filter(


### PR DESCRIPTION
1. Change logic to detect when AVD is booted
2. Introduce Promise that can be timed out
3. Remove the check for `lwc-dev-server` from base setup requirements
4. Fix issues with AVD config file that prevented an AVD to be launched from AVD Manager