### PR TITLE
Add ability to retry a failing ADB command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/lwc-dev-mobile-core",
   "description": "Core module supporting Salesforce CLI mobile extension plug-ins",
-  "version": "1.0.0-beta3",
+  "version": "1.0.0-beta4",
   "author": {
     "name": "Meisam Seyed Aliroteh",
     "email": "maliroteh@salesforce.com",

--- a/src/common/AndroidLauncher.ts
+++ b/src/common/AndroidLauncher.ts
@@ -16,6 +16,19 @@ export class AndroidLauncher {
         this.emulatorName = emulatorName;
     }
 
+    /**
+     * Attempts to preview a Lightning Web Component. It will create the target emulator if it doesn't already exist.
+     * It will launch the emulator and wait for it to boot and will then proceed to preview the LWC. If the preview
+     * target is the browser then it will launch the emulator browser for previewing the LWC. If the preview target
+     * is a native app then it will install & launch the native app for previewing the LWC.
+     *
+     * @param compName Name of the LWC component.
+     * @param projectDir Path to the LWC project root directory.
+     * @param appBundlePath Optional path to the app bundle of the native app. This will be used to install the app if not already installed.
+     * @param targetApp The bundle ID of the app to be launched.
+     * @param appConfig An AndroidAppPreviewConfig object containing app configuration info.
+     * @param serverPort The port for local dev server.
+     */
     public async launchPreview(
         compName: string,
         projectDir: string,
@@ -62,13 +75,7 @@ export class AndroidLauncher {
             })
             .then((actualPort) => {
                 emulatorPort = actualPort;
-                CommonUtils.startCliAction(
-                    `Launching`,
-                    `Waiting for device ${emuName} to boot`
-                );
-                return AndroidUtils.waitUntilDeviceIsReady(emulatorPort);
-            })
-            .then(() => {
+
                 const useServer = PreviewUtils.useLwcServerForPreviewing(
                     targetApp,
                     appConfig

--- a/src/common/AndroidTypes.ts
+++ b/src/common/AndroidTypes.ts
@@ -147,7 +147,7 @@ export class AndroidVirtualDevice {
                         .map((entry) => entry.replace('android-', ''));
                     apiLevel = Version.from(targetAPI[0]);
                 } catch (error) {
-                    // ignore and continue
+                    // fetching apiLevel is a best effort, so ignore and continue
                 }
 
                 devices.push(

--- a/src/common/AndroidTypes.ts
+++ b/src/common/AndroidTypes.ts
@@ -5,6 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { Version } from './Common';
+import fs from 'fs';
 
 export class AndroidPackages {
     public static parseRawPackagesString(
@@ -133,8 +134,31 @@ export class AndroidVirtualDevice {
             const api = AndroidVirtualDevice.getValueForKey(avd, 'based on:');
 
             if (name && device && path && target && api) {
+                const filePath = path.replace(`${name}.avd`, `${name}.ini`);
+                let apiLevel = new Version(0, 0, 0);
+                try {
+                    const configFile = fs.readFileSync(filePath, 'utf8');
+                    const targetAPI = configFile
+                        .split('\n')
+                        .filter((entry) => entry.startsWith('target='))
+                        .map((entry) =>
+                            entry.replace('target=', '').trim().toLowerCase()
+                        )
+                        .map((entry) => entry.replace('android-', ''));
+                    apiLevel = Version.from(targetAPI[0]);
+                } catch (error) {
+                    // ignore and continue
+                }
+
                 devices.push(
-                    new AndroidVirtualDevice(name, device, path, target, api)
+                    new AndroidVirtualDevice(
+                        name,
+                        device,
+                        path,
+                        target,
+                        api,
+                        apiLevel
+                    )
                 );
             }
         }
@@ -215,13 +239,15 @@ export class AndroidVirtualDevice {
     public path: string;
     public target: string;
     public api: string;
+    public apiLevel: Version;
 
     constructor(
         name: string,
         deviceName: string,
         path: string,
         target: string,
-        api: string
+        api: string,
+        apiLevel: Version
     ) {
         this.name = name;
         this.displayName = name.replace(/[_-]/gi, ' ').trim(); // eg. Pixel_XL --> Pixel XL, tv-emulator --> tv emulator
@@ -229,6 +255,7 @@ export class AndroidVirtualDevice {
         this.path = path.trim();
         this.target = target.replace(/\([^\(]*\)/gi, '').trim(); // eg. Google APIs (Google Inc.) --> Google APIs
         this.api = api.trim();
+        this.apiLevel = apiLevel;
     }
 
     public toString(): string {

--- a/src/common/CommonUtils.ts
+++ b/src/common/CommonUtils.ts
@@ -235,6 +235,24 @@ export class CommonUtils {
     }
 
     /**
+     * Launches the desktop browser and navigates to the provided URL.
+     *
+     * @returns A Promise that launches the desktop browser and navigates to the provided URL.
+     */
+    public static async launchUrlInDesktopBrowser(url: string): Promise<void> {
+        const openCmd =
+            process.platform === 'darwin'
+                ? 'open'
+                : process.platform === 'win32'
+                ? 'start'
+                : 'xdg-open';
+
+        return CommonUtils.executeCommandAsync(`${openCmd} ${url}`).then(() =>
+            Promise.resolve()
+        );
+    }
+
+    /**
      * A Promise that checks whether the local dev server plugin is installed or not.
      * The Promise will resolve if the plugin is installed and will reject otherwise.
      *

--- a/src/common/IOSLauncher.ts
+++ b/src/common/IOSLauncher.ts
@@ -16,6 +16,19 @@ export class IOSLauncher {
         this.simulatorName = simulatorName;
     }
 
+    /**
+     * Attempts to preview a Lightning Web Component. It will create the target simulator if it doesn't already exist.
+     * It will launch the simulator and wait for it to boot and will then proceed to preview the LWC. If the preview
+     * target is the browser then it will launch the simulator browser for previewing the LWC. If the preview target
+     * is a native app then it will install & launch the native app for previewing the LWC.
+     *
+     * @param compName Name of the LWC component.
+     * @param projectDir Path to the LWC project root directory.
+     * @param appBundlePath Optional path to the app bundle of the native app. This will be used to install the app if not already installed.
+     * @param targetApp The bundle ID of the app to be launched.
+     * @param appConfig An AndroidAppPreviewConfig object containing app configuration info.
+     * @param serverPort The port for local dev server.
+     */
     public async launchPreview(
         compName: string,
         projectDir: string,
@@ -65,13 +78,6 @@ export class IOSLauncher {
                     `Starting device ${deviceUDID}`
                 );
                 return IOSUtils.bootDevice(deviceUDID);
-            })
-            .then(() => {
-                CommonUtils.startCliAction(
-                    `Launching`,
-                    `Waiting for device ${deviceUDID} to boot`
-                );
-                return IOSUtils.waitUntilDeviceIsReady(deviceUDID);
             })
             .then(() => {
                 const useServer = PreviewUtils.useLwcServerForPreviewing(

--- a/src/common/IOSUtils.ts
+++ b/src/common/IOSUtils.ts
@@ -19,7 +19,7 @@ const LOGGER_NAME = 'force:lightning:local:iosutils';
 
 export class IOSUtils {
     /**
-     * Initialized the logger used by AndroidUtils
+     * Initialized the logger used by IOSUtils
      */
     public static async initializeLogger(): Promise<void> {
         IOSUtils.logger = await Logger.child(LOGGER_NAME);

--- a/src/common/IOSUtils.ts
+++ b/src/common/IOSUtils.ts
@@ -18,15 +18,33 @@ const RUNTIME_TYPE_PREFIX = 'com.apple.CoreSimulator.SimRuntime';
 const LOGGER_NAME = 'force:lightning:local:iosutils';
 
 export class IOSUtils {
+    /**
+     * Initialized the logger used by AndroidUtils
+     */
     public static async initializeLogger(): Promise<void> {
         IOSUtils.logger = await Logger.child(LOGGER_NAME);
         return Promise.resolve();
     }
 
-    public static async bootDevice(udid: string): Promise<void> {
+    /**
+     * Attempts to launch a simulator.
+     *
+     * @param udid The UDID of the simulator to launch.
+     * @param waitForBoot Optional boolean indicating whether it should wait for the device to boot up. Defaults to true.
+     */
+    public static async bootDevice(
+        udid: string,
+        waitForBoot: boolean = true
+    ): Promise<void> {
         const command = `${XCRUN_CMD} simctl boot ${udid}`;
         return CommonUtils.executeCommandAsync(command)
-            .then(() => Promise.resolve())
+            .then(() => {
+                if (waitForBoot) {
+                    return IOSUtils.waitUntilDeviceIsReady(udid);
+                } else {
+                    return Promise.resolve();
+                }
+            })
             .catch((error) => {
                 if (!IOSUtils.isDeviceAlreadyBootedError(error)) {
                     return Promise.reject(
@@ -40,6 +58,13 @@ export class IOSUtils {
             });
     }
 
+    /**
+     * Attempts to create a new simulator device.
+     *
+     * @param simulatorName The name for the simulator.
+     * @param deviceType The type of device to use for the simulator (e.g iPhone-8)
+     * @param runtime The runtime to use for the device (e.g iOS-13)
+     */
     public static async createNewDevice(
         simulatorName: string,
         deviceType: string,
@@ -57,6 +82,12 @@ export class IOSUtils {
             );
     }
 
+    /**
+     * Attempts to get the info about a simulator.
+     *
+     * @param simulatorName The name for the simulator.
+     * @returns An IOSSimulatorDevice object containing the info of a simulator, or NULL if not found.
+     */
     public static async getSimulator(
         simulatorName: string
     ): Promise<IOSSimulatorDevice | null> {
@@ -79,6 +110,11 @@ export class IOSUtils {
             });
     }
 
+    /**
+     * Attempts to get a list of simulators that are supported.
+     *
+     * @returns An array of IOSSimulatorDevice objects containing the info about the supported simulators.
+     */
     public static async getSupportedSimulators(): Promise<
         IOSSimulatorDevice[]
     > {
@@ -105,6 +141,11 @@ export class IOSUtils {
             });
     }
 
+    /**
+     * Attempts to get a list of device types that are supported.
+     *
+     * @returns An array of strings containing the supported device types.
+     */
     public static async getSupportedDevices(): Promise<string[]> {
         return CommonUtils.executeCommandAsync(
             `${XCRUN_CMD} simctl list  --json devicetypes`
@@ -143,6 +184,11 @@ export class IOSUtils {
             );
     }
 
+    /**
+     * Attempts to get a list of runtimes that are supported.
+     *
+     * @returns An array of strings containing the supported runtimes.
+     */
     public static async getSupportedRuntimes(): Promise<string[]> {
         return IOSUtils.getSimulatorRuntimes().then((configuredRuntimes) => {
             const minSupportedRuntimeIOS = Version.from(
@@ -169,6 +215,11 @@ export class IOSUtils {
         });
     }
 
+    /**
+     * Attempts to get a list of all runtimes that are available.
+     *
+     * @returns An array of strings containing all of the available runtimes.
+     */
     public static async getSimulatorRuntimes(): Promise<string[]> {
         const runtimesCmd = `${XCRUN_CMD} simctl list --json runtimes available`;
         return CommonUtils.executeCommandAsync(runtimesCmd)
@@ -209,6 +260,9 @@ export class IOSUtils {
             });
     }
 
+    /**
+     * Attempts to wait for a simulator to finish booting up.
+     */
     public static async waitUntilDeviceIsReady(udid: string): Promise<void> {
         const command = `${XCRUN_CMD} simctl bootstatus "${udid}"`;
         return CommonUtils.executeCommandAsync(command)
@@ -222,6 +276,9 @@ export class IOSUtils {
             );
     }
 
+    /**
+     * Attempts to launch the simulator app, which hosts all simulators.
+     */
     public static async launchSimulatorApp(): Promise<void> {
         const command = `open -a Simulator`;
         return CommonUtils.executeCommandAsync(command)
@@ -235,6 +292,12 @@ export class IOSUtils {
             );
     }
 
+    /**
+     * Attempts to launch the browser in a booted simulator and navigates to the provided URL.
+     *
+     * @param udid The UDID of the simulator.
+     * @param url The URL to navigate to.
+     */
     public static async launchURLInBootedSimulator(
         udid: string,
         url: string
@@ -255,6 +318,18 @@ export class IOSUtils {
             );
     }
 
+    /**
+     * Attempts to launch a native app in a simulator to preview LWC components. If the app is not installed then this method will attempt to install it first.
+     *
+     * @param udid The UDID of the simulator.
+     * @param compName Name of the LWC component.
+     * @param projectDir Path to the LWC project root directory.
+     * @param appBundlePath Optional path to the app bundle of the native app. This will be used to install the app if not already installed.
+     * @param targetApp The bundle ID of the app to be launched.
+     * @param targetAppArguments Extra arguments to be passed to the app upon launch.
+     * @param serverAddress Optional address for the server that is serving the LWC component. This will be passed to the app as an extra argument upon launch.
+     * @param serverPort Optional port for the server that is serving the LWC component. This will be passed to the app as an extra argument upon launch.
+     */
     public static async launchAppInBootedSimulator(
         udid: string,
         compName: string,

--- a/src/common/PlatformConfig.ts
+++ b/src/common/PlatformConfig.ts
@@ -60,4 +60,5 @@ export class AndroidConfig {
     public readonly defaultEmulatorName: string = 'SFDXEmulator';
     public readonly defaultAdbPort: number = 5572;
     public readonly deviceReadinessWaitTime: number = 120000;
+    public readonly AdbRetryAttemptDelay: number = 1000;
 }

--- a/src/common/PlatformConfig.ts
+++ b/src/common/PlatformConfig.ts
@@ -59,5 +59,5 @@ export class AndroidConfig {
     ];
     public readonly defaultEmulatorName: string = 'SFDXEmulator';
     public readonly defaultAdbPort: number = 5572;
-    public readonly deviceBootReadinessWaitTime: number = 120000;
+    public readonly deviceReadinessWaitTime: number = 120000;
 }

--- a/src/common/PlatformConfig.ts
+++ b/src/common/PlatformConfig.ts
@@ -60,5 +60,6 @@ export class AndroidConfig {
     public readonly defaultEmulatorName: string = 'SFDXEmulator';
     public readonly defaultAdbPort: number = 5572;
     public readonly deviceReadinessWaitTime: number = 120000;
-    public readonly AdbRetryAttemptDelay: number = 1000;
+    public readonly AdbNumRetryAttempts: number = 6;
+    public readonly AdbRetryAttemptDelay: number = 500;
 }


### PR DESCRIPTION
1. Add support for retry mechanism to re-execute a failing ADB command
2. Add methods to `AndroidUtils` to easily allow for remounting as root with writable system access
3. Add `apiLevel` to `AndroidVirtualDevice` and the code to fetch its value from an AVDs config file
4. Some cleanup