### PR TITLE
Few more refactors for AndroidUtils

### DIFF
--- a/src/common/AndroidLauncher.ts
+++ b/src/common/AndroidLauncher.ts
@@ -42,7 +42,6 @@ export class AndroidLauncher {
         const androidApi = preferredPack.platformAPI;
         const abi = preferredPack.abi;
         const device = (await AndroidUtils.getSupportedDevices())[0];
-        let emulatorPort = await AndroidUtils.getNextAndroidAdbPort();
         const emuName = this.emulatorName;
         CommonUtils.startCliAction(`Launching`, `Searching for ${emuName}`);
         return AndroidUtils.hasEmulator(emuName)
@@ -71,11 +70,9 @@ export class AndroidLauncher {
                     `Launching`,
                     `Starting device ${emuName}`
                 );
-                return AndroidUtils.startEmulator(emuName, emulatorPort);
+                return AndroidUtils.startEmulator(emuName);
             })
-            .then((actualPort) => {
-                emulatorPort = actualPort;
-
+            .then((emulatorPort) => {
                 const useServer = PreviewUtils.useLwcServerForPreviewing(
                     targetApp,
                     appConfig


### PR DESCRIPTION
This PR contains a few more refactors/cleanups to `AndroidUtils` functions:

1. Do away with passing "requested" port to `startEmulator` and having it return "actual" port. That's just confusing.

2. Make a few functions private since they are only to be used internally by `AndroidUtils`

3. Update `mountAsRootWritableSystem` to take emulator name instead of the port. Also instead of returning `void` it now returns the port number of the AVD (in case it had to be (re)launched in writable-system mode)

4. Clean up code around determining the current port that an emulator is running on, or what the next available adb port is.

5. Change the logic of determining whether an AVD is already running. Previously we were relying on the existence of a magic file and names of running processes, and this is not robust. Instead changed the logic to get the name of the running AVDs and if a match is found then return the matching port. Hopefully this is a much more stable approach.