### PR TITLE
differ initialization to caller

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/lwc-dev-mobile-core",
   "description": "Core module supporting Salesforce CLI mobile extension plug-ins",
-  "version": "1.0.0-beta10",
+  "version": "1.0.0-beta11",
   "author": {
     "name": "Meisam Seyed Aliroteh",
     "email": "maliroteh@salesforce.com",

--- a/src/cli/commands/force/lightning/local/__tests__/setup.test.ts
+++ b/src/cli/commands/force/lightning/local/__tests__/setup.test.ts
@@ -41,12 +41,14 @@ describe('Setup Tests', () => {
 
     test('Checks that Setup is initialized correctly for iOS', async () => {
         const setup = makeSetup(PlatformType.ios);
+        await setup.init();
         await setup.run();
         expect(executeSetupMock).toHaveBeenCalled();
     });
 
     test('Checks that Setup is initialized correctly for Android', async () => {
         const setup = makeSetup(PlatformType.android);
+        await setup.init();
         await setup.run();
         expect(executeSetupMock).toHaveBeenCalled();
     });
@@ -55,6 +57,7 @@ describe('Setup Tests', () => {
         const setup = makeSetup('someplatform');
         expect.assertions(2);
         try {
+            await setup.init();
             await setup.run();
         } catch (error) {
             expect(error instanceof SfdxError).toBe(true);
@@ -69,6 +72,7 @@ describe('Setup Tests', () => {
 
         expect.assertions(2);
         try {
+            await setup.init();
             await setup.run();
         } catch (error) {
             const expectedMsg = util
@@ -91,11 +95,13 @@ describe('Setup Tests', () => {
         expect.assertions(3);
 
         let setup = makeSetup(PlatformType.ios, '1.2.3');
+        await setup.init();
         await setup.run();
         expect(executeSetupMock).toHaveBeenCalled();
 
         setup = makeSetup(PlatformType.ios, 'not-a-number');
         try {
+            await setup.init();
             await setup.run();
         } catch (error) {
             expect(error instanceof SfdxError).toBe(true);
@@ -119,6 +125,7 @@ describe('Setup Tests', () => {
             LoggerSetup,
             'initializePluginLoggers'
         );
+        await setup.init();
         await setup.run();
         expect(loggerSpy).toHaveBeenCalled();
         expect(LoggerSetupSpy).toHaveBeenCalled();

--- a/src/cli/commands/force/lightning/local/setup.ts
+++ b/src/cli/commands/force/lightning/local/setup.ts
@@ -32,15 +32,23 @@ const messages = Messages.loadMessages(
 export class Setup extends SfdxCommand implements HasRequirements {
     public static description = messages.getMessage('commandDescription');
 
-    public static readonly flagsConfig: FlagsConfig = {
-        ...CommandLineUtils.createFlagConfig(FlagsConfigType.ApiLevel, false),
-        ...CommandLineUtils.createFlagConfig(FlagsConfigType.Platform, true)
-    };
-
-    public examples = [
+    public static examples = [
         `sfdx force:lightning:local:setup -p iOS`,
         `sfdx force:lightning:local:setup -p Android`
     ];
+
+    public static readonly flagsConfig: FlagsConfig = {
+        ...CommandLineUtils.createFlagConfig(
+            FlagsConfigType.ApiLevel,
+            false,
+            Setup.examples
+        ),
+        ...CommandLineUtils.createFlagConfig(
+            FlagsConfigType.Platform,
+            true,
+            Setup.examples
+        )
+    };
 
     public async run(): Promise<any> {
         this.logger.info(`Setup command called for ${this.flags.platform}`);

--- a/src/cli/commands/force/lightning/local/setup.ts
+++ b/src/cli/commands/force/lightning/local/setup.ts
@@ -30,8 +30,6 @@ const messages = Messages.loadMessages(
 );
 
 export class Setup extends SfdxCommand implements HasRequirements {
-    private _commandRequirements: CommandRequirements = {};
-
     public static description = messages.getMessage('commandDescription');
 
     public static readonly flagsConfig: FlagsConfig = {
@@ -45,23 +43,11 @@ export class Setup extends SfdxCommand implements HasRequirements {
     ];
 
     public async run(): Promise<any> {
-        try {
-            await this.init(); // ensure init first
-        } catch (error) {
-            if (error instanceof SfdxError) {
-                const sfdxError = error as SfdxError;
-                sfdxError.actions = this.examples;
-                throw sfdxError;
-            }
-            throw error;
-        }
-
         this.logger.info(`Setup command called for ${this.flags.platform}`);
-
         return RequirementProcessor.execute(this.commandRequirements);
     }
 
-    protected async init(): Promise<void> {
+    public async init(): Promise<void> {
         if (this.logger) {
             // already initialized
             return Promise.resolve();
@@ -76,6 +62,7 @@ export class Setup extends SfdxCommand implements HasRequirements {
             });
     }
 
+    private _commandRequirements: CommandRequirements = {};
     public get commandRequirements(): CommandRequirements {
         if (Object.keys(this._commandRequirements).length === 0) {
             const requirements = CommandLineUtils.platformFlagIsAndroid(

--- a/src/cli/commands/force/lightning/local/setup.ts
+++ b/src/cli/commands/force/lightning/local/setup.ts
@@ -32,23 +32,15 @@ const messages = Messages.loadMessages(
 export class Setup extends SfdxCommand implements HasRequirements {
     public static description = messages.getMessage('commandDescription');
 
-    public static examples = [
+    public static readonly flagsConfig: FlagsConfig = {
+        ...CommandLineUtils.createFlagConfig(FlagsConfigType.ApiLevel, false),
+        ...CommandLineUtils.createFlagConfig(FlagsConfigType.Platform, true)
+    };
+
+    public examples = [
         `sfdx force:lightning:local:setup -p iOS`,
         `sfdx force:lightning:local:setup -p Android`
     ];
-
-    public static readonly flagsConfig: FlagsConfig = {
-        ...CommandLineUtils.createFlagConfig(
-            FlagsConfigType.ApiLevel,
-            false,
-            Setup.examples
-        ),
-        ...CommandLineUtils.createFlagConfig(
-            FlagsConfigType.Platform,
-            true,
-            Setup.examples
-        )
-    };
 
     public async run(): Promise<any> {
         this.logger.info(`Setup command called for ${this.flags.platform}`);
@@ -60,6 +52,8 @@ export class Setup extends SfdxCommand implements HasRequirements {
             // already initialized
             return Promise.resolve();
         }
+
+        CommandLineUtils.flagFailureActionMessages = this.examples;
 
         return super
             .init()

--- a/src/common/Common.ts
+++ b/src/common/Common.ts
@@ -126,12 +126,10 @@ export class CommandLineUtils {
 
     public static createFlagConfig(
         type: FlagsConfigType,
-        required: boolean,
-        actionMessages: string[]
+        required: boolean
     ): FlagsConfig {
         switch (type) {
             case FlagsConfigType.ApiLevel:
-                CommandLineUtils.apiLevelFlagFailureActionMessages = actionMessages;
                 return {
                     apilevel: flags.string({
                         char: 'l',
@@ -146,7 +144,6 @@ export class CommandLineUtils {
                     })
                 };
             case FlagsConfigType.Platform:
-                CommandLineUtils.platformFlagFailureActionMessages = actionMessages;
                 return {
                     platform: flags.string({
                         char: 'p',
@@ -163,7 +160,8 @@ export class CommandLineUtils {
         }
     }
 
-    private static apiLevelFlagFailureActionMessages: string[] = [];
+    public static flagFailureActionMessages: string[] = [];
+
     private static validateApiLevelFlag(flag: string): boolean {
         try {
             Version.from(flag);
@@ -176,19 +174,18 @@ export class CommandLineUtils {
                     error
                 ),
                 'lwc-dev-mobile-core',
-                CommandLineUtils.apiLevelFlagFailureActionMessages
+                CommandLineUtils.flagFailureActionMessages
             );
         }
         return true;
     }
 
-    private static platformFlagFailureActionMessages: string[] = [];
     private static validatePlatformFlag(flag: string): boolean {
         if (!CommandLineUtils.platformFlagIsValid(flag)) {
             throw new SfdxError(
                 messages.getMessage('error:invalidInputFlagsDescription'),
                 'lwc-dev-mobile-core',
-                CommandLineUtils.platformFlagFailureActionMessages
+                CommandLineUtils.flagFailureActionMessages
             );
         }
 

--- a/src/common/Common.ts
+++ b/src/common/Common.ts
@@ -126,10 +126,12 @@ export class CommandLineUtils {
 
     public static createFlagConfig(
         type: FlagsConfigType,
-        required: boolean
+        required: boolean,
+        actionMessages: string[]
     ): FlagsConfig {
         switch (type) {
             case FlagsConfigType.ApiLevel:
+                CommandLineUtils.apiLevelFlagFailureActionMessages = actionMessages;
                 return {
                     apilevel: flags.string({
                         char: 'l',
@@ -144,6 +146,7 @@ export class CommandLineUtils {
                     })
                 };
             case FlagsConfigType.Platform:
+                CommandLineUtils.platformFlagFailureActionMessages = actionMessages;
                 return {
                     platform: flags.string({
                         char: 'p',
@@ -160,6 +163,7 @@ export class CommandLineUtils {
         }
     }
 
+    private static apiLevelFlagFailureActionMessages: string[] = [];
     private static validateApiLevelFlag(flag: string): boolean {
         try {
             Version.from(flag);
@@ -171,17 +175,20 @@ export class CommandLineUtils {
                     ),
                     error
                 ),
-                'lwc-dev-mobile-core'
+                'lwc-dev-mobile-core',
+                CommandLineUtils.apiLevelFlagFailureActionMessages
             );
         }
         return true;
     }
 
+    private static platformFlagFailureActionMessages: string[] = [];
     private static validatePlatformFlag(flag: string): boolean {
         if (!CommandLineUtils.platformFlagIsValid(flag)) {
             throw new SfdxError(
                 messages.getMessage('error:invalidInputFlagsDescription'),
-                'lwc-dev-mobile-core'
+                'lwc-dev-mobile-core',
+                CommandLineUtils.platformFlagFailureActionMessages
             );
         }
 

--- a/src/common/__tests__/Common.test.ts
+++ b/src/common/__tests__/Common.test.ts
@@ -144,8 +144,7 @@ describe('Commons utils tests', () => {
     test('Platform flag config property returns expected flag', async () => {
         let platformFlagConfig = common.CommandLineUtils.createFlagConfig(
             common.FlagsConfigType.Platform,
-            true,
-            []
+            true
         );
         expect(platformFlagConfig.platform).toBeDefined();
         expect(platformFlagConfig.platform!.longDescription).toBe(
@@ -163,8 +162,7 @@ describe('Commons utils tests', () => {
 
         platformFlagConfig = common.CommandLineUtils.createFlagConfig(
             common.FlagsConfigType.Platform,
-            false,
-            []
+            false
         );
 
         requiredKeyValuePair = Object.entries(
@@ -178,8 +176,7 @@ describe('Commons utils tests', () => {
     test('API level flag config property returns expected flag', async () => {
         let apiLevelFlagConfig = common.CommandLineUtils.createFlagConfig(
             common.FlagsConfigType.ApiLevel,
-            true,
-            []
+            true
         );
         expect(apiLevelFlagConfig.apilevel).toBeDefined();
         expect(apiLevelFlagConfig.apilevel!.longDescription).toBe(
@@ -198,8 +195,7 @@ describe('Commons utils tests', () => {
 
         apiLevelFlagConfig = common.CommandLineUtils.createFlagConfig(
             common.FlagsConfigType.ApiLevel,
-            false,
-            []
+            false
         );
 
         requiredKeyValuePair = Object.entries(

--- a/src/common/__tests__/Common.test.ts
+++ b/src/common/__tests__/Common.test.ts
@@ -144,7 +144,8 @@ describe('Commons utils tests', () => {
     test('Platform flag config property returns expected flag', async () => {
         let platformFlagConfig = common.CommandLineUtils.createFlagConfig(
             common.FlagsConfigType.Platform,
-            true
+            true,
+            []
         );
         expect(platformFlagConfig.platform).toBeDefined();
         expect(platformFlagConfig.platform!.longDescription).toBe(
@@ -162,7 +163,8 @@ describe('Commons utils tests', () => {
 
         platformFlagConfig = common.CommandLineUtils.createFlagConfig(
             common.FlagsConfigType.Platform,
-            false
+            false,
+            []
         );
 
         requiredKeyValuePair = Object.entries(
@@ -176,7 +178,8 @@ describe('Commons utils tests', () => {
     test('API level flag config property returns expected flag', async () => {
         let apiLevelFlagConfig = common.CommandLineUtils.createFlagConfig(
             common.FlagsConfigType.ApiLevel,
-            true
+            true,
+            []
         );
         expect(apiLevelFlagConfig.apilevel).toBeDefined();
         expect(apiLevelFlagConfig.apilevel!.longDescription).toBe(
@@ -195,7 +198,8 @@ describe('Commons utils tests', () => {
 
         apiLevelFlagConfig = common.CommandLineUtils.createFlagConfig(
             common.FlagsConfigType.ApiLevel,
-            false
+            false,
+            []
         );
 
         requiredKeyValuePair = Object.entries(


### PR DESCRIPTION
Making it the responsibility of the caller to initialize a command. If we invoke a command from command line then SFDX will initialize the command already. If we instantiate a command object in code then we would be responsible for initializing before using the command.