### PR TITLE
Handle Android codename package versions gracefully

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/lwc-dev-mobile-core",
   "description": "Core module supporting Salesforce CLI mobile extension plug-ins",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": {
     "name": "Meisam Seyed Aliroteh",
     "email": "maliroteh@salesforce.com",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/lwc-dev-mobile-core",
   "description": "Core module supporting Salesforce CLI mobile extension plug-ins",
-  "version": "1.3.1",
+  "version": "2.0.0",
   "author": {
     "name": "Meisam Seyed Aliroteh",
     "email": "maliroteh@salesforce.com",

--- a/src/cli/commands/force/lightning/local/__tests__/setup.test.ts
+++ b/src/cli/commands/force/lightning/local/__tests__/setup.test.ts
@@ -97,7 +97,9 @@ describe('Setup Tests', () => {
         await setup.run();
         expect(executeSetupMock).toHaveBeenCalled();
 
-        setup = makeSetup(PlatformType.ios, 'not-a-number');
+        const invalidVersionFlag = 'not-a-number';
+
+        setup = makeSetup(PlatformType.ios, invalidVersionFlag);
         try {
             await setup.init();
             await setup.run();
@@ -108,7 +110,7 @@ describe('Setup Tests', () => {
                     messages.getMessage(
                         'error:invalidApiLevelFlagsDescription'
                     ),
-                    'Error: Invalid version string: not-a-number'
+                    invalidVersionFlag
                 )
             );
         }

--- a/src/common/IOSUtils.ts
+++ b/src/common/IOSUtils.ts
@@ -208,12 +208,30 @@ export class IOSUtils {
             const minSupportedRuntimeIOS = Version.from(
                 PlatformConfig.iOSConfig().minSupportedRuntime
             );
+            if (minSupportedRuntimeIOS === null) {
+                return Promise.reject(
+                    new SfdxError(
+                        `${
+                            PlatformConfig.iOSConfig().minSupportedRuntime
+                        } is not a supported version format.`
+                    )
+                );
+            }
 
             const rtIntersection = configuredRuntimes.filter(
                 (configuredRuntime) => {
                     const configuredRuntimeVersion = Version.from(
                         configuredRuntime.toLowerCase().replace('ios-', '')
                     );
+                    if (configuredRuntimeVersion === null) {
+                        // We haven't hit a use case where Apple does unconventional version
+                        // specifications like Google will do with their codename "versions".
+                        // So for now, this is a 'miss' on the iOS side. Prove me wrong, Apple!
+                        IOSUtils.logger.warn(
+                            `getSupportedRuntimes(): getSimulatorRuntimes() returned '${configuredRuntime}', which is not a supported version format.`
+                        );
+                        return false;
+                    }
 
                     return configuredRuntimeVersion.sameOrNewer(
                         minSupportedRuntimeIOS

--- a/src/common/LoggerSetup.ts
+++ b/src/common/LoggerSetup.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { AndroidPackages, AndroidVirtualDevice } from './AndroidTypes';
 import { AndroidUtils } from './AndroidUtils';
 import { CommonUtils } from './CommonUtils';
 import { IOSUtils } from './IOSUtils';
@@ -18,6 +19,8 @@ export class LoggerSetup {
         await IOSUtils.initializeLogger();
         await CommonUtils.initializeLogger();
         await MacNetworkUtils.initializeLogger();
+        await AndroidPackages.initializeLogger();
+        await AndroidVirtualDevice.initializeLogger();
         return Promise.resolve();
     }
 }

--- a/src/common/__tests__/AndroidMockData.ts
+++ b/src/common/__tests__/AndroidMockData.ts
@@ -18,6 +18,7 @@ export class AndroidMockData {
       platforms;android-28                                | 6            | Android SDK Platform 28                         | platforms/android-28/                               
       platforms;android-29                                | 3            | Android SDK Platform 29                         | platforms/android-29/                               
       platforms;android-30                                | 3            | Android SDK Platform 30                         | platforms/android-30/                               
+      platforms;android-Tiramisu                          | 2            | Android SDK Platform Tiramisu                   | platforms/android-Tiramisu/                               
       system-images;android-28;default;x86_64             | 4            | Intel x86 Atom_64 System Image                  | system-images/android-28/default/x86_64/            
       system-images;android-28;google_apis;x86            | 10           | Google APIs Intel x86 Atom System Image         | system-images/android-28/google_apis/x86/           
       system-images;android-28;google_apis_playstore;x86  | 9            | Google Play Intel x86 Atom System Image         | system-images/android-28/google_apis_playstore/x86/ 
@@ -25,6 +26,7 @@ export class AndroidMockData {
       system-images;android-29;google_apis;x86            | 8            | Google APIs Intel x86 Atom System Image         | system-images/android-29/google_apis/x86/           
       system-images;android-30;google_apis;x86            | 9            | Google APIs Intel x86 Atom System Image         | system-images/android-30/google_apis/x86/           
       system-images;android-30;google_apis;x86_64         | 9            | Google APIs Intel x86 Atom_64 System Image      | system-images/android-30/google_apis/x86_64/        
+      system-images;android-Tiramisu;google_apis;x86_64   | 1            | Google APIs Intel x86 Atom_64 System Image      | system-images/android-Tiramisu/google_apis/x86_64/        
       tools                                               | 26.1.1       | Android SDK Tools 26.1.1                        | tools/                                              
     Available Packages:
       Path                                                                                     | Version      | Description                                                         
@@ -33,6 +35,9 @@ export class AndroidMockData {
     public static badMockRawPackagesString =
         'Installed packages:=====================]';
 
+    // NB: There are two codename packages in the output above, which should be
+    // ignored by parsing as of this release. This value represents an implicit
+    // test of discarding that data. The real count above is this value + 2.
     public static mockRawStringPackageLength = 13;
 
     public static avdList = `

--- a/src/common/__tests__/AndroidUtils.test.ts
+++ b/src/common/__tests__/AndroidUtils.test.ts
@@ -242,7 +242,7 @@ describe('Android utils', () => {
         expect(apiPackage !== null && apiPackage.description !== null).toBe(
             true
         );
-        expect(apiPackage.version.same(Version.from('28'))).toBe(true);
+        expect(apiPackage.version.same(Version.from('28')!)).toBe(true);
     });
 
     test('Should not find a preferred Android package', async () => {

--- a/src/common/__tests__/Common.test.ts
+++ b/src/common/__tests__/Common.test.ts
@@ -208,4 +208,67 @@ describe('Commons utils tests', () => {
         expect(requiredKeyValuePair).toBeDefined();
         expect(requiredKeyValuePair![1]).toBe(false);
     });
+
+    test('Valid Version formats return expected object values', async () => {
+        // Major only.
+        const v1 = common.Version.from('1');
+        expect(v1?.major).toBe(1);
+        expect(v1?.minor).toBe(0);
+        expect(v1?.patch).toBe(0);
+
+        // Major and minor only.
+        for (const versionString of ['2.3', '2-3']) {
+            const v2 = common.Version.from(versionString);
+            expect(v2?.major).toBe(2);
+            expect(v2?.minor).toBe(3);
+            expect(v2?.patch).toBe(0);
+        }
+
+        // Major, minor, and patch.
+        for (const versionString of ['4.5.6', '4-5-6']) {
+            const v3 = common.Version.from(versionString);
+            expect(v3?.major).toBe(4);
+            expect(v3?.minor).toBe(5);
+            expect(v3?.patch).toBe(6);
+        }
+
+        // Space-padded values.
+        for (const versionString of ['  7.8.9  ', '  7-8-9  ']) {
+            const v4 = common.Version.from(versionString);
+            expect(v4?.major).toBe(7);
+            expect(v4?.minor).toBe(8);
+            expect(v4?.patch).toBe(9);
+        }
+
+        // Multi-digit values.
+        for (const versionString of ['10.111.1212', '10-111-1212']) {
+            const v5 = common.Version.from(versionString);
+            expect(v5?.major).toBe(10);
+            expect(v5?.minor).toBe(111);
+            expect(v5?.patch).toBe(1212);
+        }
+
+        // 'Zero' releases.
+        for (const versionString of ['0.1.2', '0-1-2']) {
+            const v6 = common.Version.from(versionString);
+            expect(v6?.major).toBe(0);
+            expect(v6?.minor).toBe(1);
+            expect(v6?.patch).toBe(2);
+        }
+    });
+
+    test('Invalid Version formats return null', async () => {
+        const invalidVersions = [
+            'some-random-string',
+            '001.002.003',
+            '004-005-006',
+            '2-3.4',
+            '2.3-4',
+            '5.6.7.8',
+            '9-10-11-12'
+        ];
+        for (const invalidVersion of invalidVersions) {
+            expect(common.Version.from(invalidVersion)).toBeNull();
+        }
+    });
 });


### PR DESCRIPTION
This should handle the scenario where a user has Android codename version packages in their local SDK. Before, these would result in an unhandled error.