### PR TITLE
Add ability to run command using spawn()

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+network-timeout 600000

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/lwc-dev-mobile-core",
   "description": "Core module supporting Salesforce CLI mobile extension plug-ins",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "author": {
     "name": "Meisam Seyed Aliroteh",
     "email": "maliroteh@salesforce.com",


### PR DESCRIPTION
After reading [this](https://www.freecodecamp.org/news/node-js-child-processes-everything-you-need-to-know-e69498fe970a/) blog post, I'm adding a method for running commands using `child_process.spawn()`. According to that blog post, we should be using `spawn` instead of `exec` if we expect to have a long running process which might produce a large amount of output. By adding this new method, we can use it in `lwc-dev-mobile` when running WDIO related commands which may produce large amount of output.

Furthermore, when using `exec` the content of `stdout` and `stderr` will be captured and send to the caller **_after_** the execution is done. Whereas using `spawn` we have the option of streaming the stdio to the caller while the command is running.