### PR TITLE
Add support for logLevel and json flags

### DIFF
--- a/messages/common.json
+++ b/messages/common.json
@@ -28,5 +28,7 @@
 
     "platformFlagDescription": "Specify platform ('iOS' or 'Android').",
     "apiLevelFlagDescription": "Specify Android API level. Defaults to the latest API level installed.",
+    "jsonFlagDescription": "Format output as json.",
+    "logLevelFlagDescription": "Logging level for this command invocation (options: TRACE, DEBUG, INFO, WARN, ERROR, FATAL).",
     "error:invalidFlagValue": "Invalid value: %s"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/lwc-dev-mobile-core",
   "description": "Core module supporting Salesforce CLI mobile extension plug-ins",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": {
     "name": "Meisam Seyed Aliroteh",
     "email": "maliroteh@salesforce.com",

--- a/src/cli/commands/force/lightning/local/setup.ts
+++ b/src/cli/commands/force/lightning/local/setup.ts
@@ -39,6 +39,8 @@ export class Setup extends BaseCommand {
     ];
 
     public static readonly flags = {
+        ...CommandLineUtils.createFlag(FlagsConfigType.Json, false),
+        ...CommandLineUtils.createFlag(FlagsConfigType.LogLevel, false),
         ...CommandLineUtils.createFlag(FlagsConfigType.ApiLevel, false),
         ...CommandLineUtils.createFlag(FlagsConfigType.Platform, true)
     };

--- a/src/common/AndroidTypes.ts
+++ b/src/common/AndroidTypes.ts
@@ -6,7 +6,7 @@
  */
 import { Version } from './Common';
 import fs from 'fs';
-import { Logger } from '@salesforce/core';
+import { Logger, LoggerLevelValue } from '@salesforce/core';
 
 const ANDROID_PACKAGES_LOGGER_NAME =
     'force:lightning:local:androidtypes:androidpackages';
@@ -17,10 +17,13 @@ export class AndroidPackages {
     /**
      * Initialize the logger used by AndroidPackages.
      */
-    public static async initializeLogger(): Promise<void> {
+    public static async initializeLogger(
+        level?: LoggerLevelValue
+    ): Promise<void> {
         AndroidPackages.logger = await Logger.child(
             ANDROID_PACKAGES_LOGGER_NAME
         );
+        AndroidPackages.logger.setLevel(level);
         return Promise.resolve();
     }
 
@@ -199,10 +202,13 @@ export class AndroidVirtualDevice {
     /**
      * Initialize the logger used by AndroidVirtualDevice.
      */
-    public static async initializeLogger(): Promise<void> {
+    public static async initializeLogger(
+        level?: LoggerLevelValue
+    ): Promise<void> {
         AndroidVirtualDevice.logger = await Logger.child(
             ANDROID_VIRTUAL_DEVICE_LOGGER_NAME
         );
+        AndroidVirtualDevice.logger.setLevel(level);
         return Promise.resolve();
     }
 

--- a/src/common/AndroidUtils.ts
+++ b/src/common/AndroidUtils.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { Logger, Messages, SfError } from '@salesforce/core';
+import { Logger, LoggerLevelValue, Messages, SfError } from '@salesforce/core';
 import * as childProcess from 'child_process';
 import fs from 'fs';
 import path from 'path';
@@ -50,8 +50,11 @@ export class AndroidUtils {
     /**
      * Initialized the logger used by AndroidUtils
      */
-    public static async initializeLogger(): Promise<void> {
+    public static async initializeLogger(
+        level?: LoggerLevelValue
+    ): Promise<void> {
         AndroidUtils.logger = await Logger.child(LOGGER_NAME);
+        AndroidUtils.logger.setLevel(level);
         return Promise.resolve();
     }
 

--- a/src/common/BaseCommand.ts
+++ b/src/common/BaseCommand.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { SfCommand } from '@salesforce/sf-plugins-core';
-import { Logger } from '@salesforce/core';
+import { Logger, LoggerLevel } from '@salesforce/core';
 import { CommandLineUtils } from './Common';
 import { LoggerSetup } from './LoggerSetup';
 import { HasRequirements, CommandRequirements } from './Requirements';
@@ -55,8 +55,18 @@ export abstract class BaseCommand
                 return Logger.child(this.commandName);
             })
             .then((logger) => {
+                // extract the log level flag (if any) and
+                // set the logger's level to this value
+                const logLevelFlag: string | undefined = (
+                    this._flagValues.loglevel as string
+                )
+                    ?.trim()
+                    ?.toUpperCase();
+                const logLevel =
+                    logLevelFlag && (<any>LoggerLevel)[logLevelFlag];
+                logger.setLevel(logLevel);
                 this._logger = logger;
-                return LoggerSetup.initializePluginLoggers();
+                return LoggerSetup.initializePluginLoggers(logLevel);
             })
             .then(() => this.populateCommandRequirements());
     }

--- a/src/common/Common.ts
+++ b/src/common/Common.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { Flags, SfCommand } from '@salesforce/sf-plugins-core';
-import { Messages, SfError, Logger } from '@salesforce/core';
+import { Logger, LoggerLevel, Messages, SfError } from '@salesforce/core';
 import util from 'util';
 import {
     CustomOptions,
@@ -69,7 +69,9 @@ export class SetUtils {
 
 export enum FlagsConfigType {
     Platform,
-    ApiLevel
+    ApiLevel,
+    LogLevel,
+    Json
 }
 
 // tslint:disable-next-line: max-classes-per-file
@@ -151,6 +153,27 @@ export class CommandLineUtils {
                         ),
                         required: isRequired,
                         validate: CommandLineUtils.validatePlatformFlag
+                    })
+                };
+            case FlagsConfigType.LogLevel:
+                return {
+                    loglevel: Flags.string({
+                        description: messages.getMessage(
+                            'logLevelFlagDescription'
+                        ),
+                        required: false,
+                        default: LoggerLevel[LoggerLevel.WARN],
+                        validate: (level: string) =>
+                            level &&
+                            (<any>LoggerLevel)[level.trim().toUpperCase()]
+                    })
+                };
+            case FlagsConfigType.Json:
+                return {
+                    json: Flags.boolean({
+                        description: messages.getMessage('jsonFlagDescription'),
+                        required: false,
+                        default: false
                     })
                 };
         }

--- a/src/common/CommonUtils.ts
+++ b/src/common/CommonUtils.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { Logger, SfError } from '@salesforce/core';
+import { Logger, LoggerLevelValue, SfError } from '@salesforce/core';
 import * as childProcess from 'child_process';
 import { ux } from '@oclif/core';
 import fs from 'fs';
@@ -24,8 +24,11 @@ export class CommonUtils {
     /**
      * Initializes the logger used by CommonUtils for logging activities.
      */
-    public static async initializeLogger(): Promise<void> {
+    public static async initializeLogger(
+        level?: LoggerLevelValue
+    ): Promise<void> {
         CommonUtils.logger = await Logger.child(LOGGER_NAME);
+        CommonUtils.logger.setLevel(level);
         return Promise.resolve();
     }
 

--- a/src/common/IOSUtils.ts
+++ b/src/common/IOSUtils.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { Logger, Messages, SfError } from '@salesforce/core';
+import { Logger, LoggerLevelValue, Messages, SfError } from '@salesforce/core';
 import util from 'util';
 import { Version } from '../common/Common';
 import { CommonUtils } from './CommonUtils';
@@ -32,8 +32,11 @@ export class IOSUtils {
     /**
      * Initialized the logger used by IOSUtils
      */
-    public static async initializeLogger(): Promise<void> {
+    public static async initializeLogger(
+        level?: LoggerLevelValue
+    ): Promise<void> {
         IOSUtils.logger = await Logger.child(LOGGER_NAME);
+        IOSUtils.logger.setLevel(level);
         return Promise.resolve();
     }
 

--- a/src/common/LoggerSetup.ts
+++ b/src/common/LoggerSetup.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { LoggerLevelValue } from '@salesforce/core';
 import { AndroidPackages, AndroidVirtualDevice } from './AndroidTypes';
 import { AndroidUtils } from './AndroidUtils';
 import { CommonUtils } from './CommonUtils';
@@ -14,13 +15,15 @@ export class LoggerSetup {
     /**
      * Initializes all of the loggers that various utility libraries use (such as AndroidUtils, IOSUtils, CommonUtils)
      */
-    public static async initializePluginLoggers(): Promise<void> {
-        await AndroidUtils.initializeLogger();
-        await IOSUtils.initializeLogger();
-        await CommonUtils.initializeLogger();
-        await MacNetworkUtils.initializeLogger();
-        await AndroidPackages.initializeLogger();
-        await AndroidVirtualDevice.initializeLogger();
+    public static async initializePluginLoggers(
+        level?: LoggerLevelValue
+    ): Promise<void> {
+        await AndroidUtils.initializeLogger(level);
+        await IOSUtils.initializeLogger(level);
+        await CommonUtils.initializeLogger(level);
+        await MacNetworkUtils.initializeLogger(level);
+        await AndroidPackages.initializeLogger(level);
+        await AndroidVirtualDevice.initializeLogger(level);
         return Promise.resolve();
     }
 }

--- a/src/common/MacNetworkUtils.ts
+++ b/src/common/MacNetworkUtils.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { Logger, SfError } from '@salesforce/core';
+import { Logger, LoggerLevelValue, SfError } from '@salesforce/core';
 import { CommonUtils } from './CommonUtils';
 import net from 'net';
 import util from 'util';
@@ -26,8 +26,11 @@ export class MacNetworkUtils {
     /**
      * Initialized the logger used by MacNetworkUtils
      */
-    public static async initializeLogger(): Promise<void> {
+    public static async initializeLogger(
+        level?: LoggerLevelValue
+    ): Promise<void> {
         MacNetworkUtils.logger = await Logger.child(LOGGER_NAME);
+        MacNetworkUtils.logger.setLevel(level);
         return Promise.resolve();
     }
 


### PR DESCRIPTION
Bring back these flags for backwards compatibility since SFDX VSCode Extension is still using older version of `SfCommand`