### PR TITLE
Add support for codenamed version strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/lwc-dev-mobile-core",
   "description": "Core module supporting Salesforce CLI mobile extension plug-ins",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "author": {
     "name": "Meisam Seyed Aliroteh",
     "email": "maliroteh@salesforce.com",

--- a/src/cli/commands/force/lightning/local/__tests__/setup.test.ts
+++ b/src/cli/commands/force/lightning/local/__tests__/setup.test.ts
@@ -72,47 +72,11 @@ describe('Setup Tests', () => {
         }
     });
 
-    test('Checks that Setup fails for invalid API Level flag', async () => {
-        const setup = makeSetup(PlatformType.android, 'not-a-number');
-
-        expect.assertions(2);
-        try {
-            await setup.init();
-            await setup.run();
-        } catch (error) {
-            expect(error instanceof SfError).toBe(true);
-            expect((error as SfError).message).toContain(
-                util.format(
-                    messages.getMessage('error:invalidFlagValue'),
-                    'not-a-number'
-                )
-            );
-        }
-    });
-
     test('Checks that Setup will still validate API Level flag for iOS platform if passed a value', async () => {
-        expect.assertions(3);
-
-        let setup = makeSetup(PlatformType.ios, '1.2.3');
+        const setup = makeSetup(PlatformType.ios, '1.2.3');
         await setup.init();
         await setup.run();
         expect(executeSetupMock).toHaveBeenCalled();
-
-        const invalidVersionFlag = 'not-a-number';
-
-        setup = makeSetup(PlatformType.ios, invalidVersionFlag);
-        try {
-            await setup.init();
-            await setup.run();
-        } catch (error) {
-            expect(error instanceof SfError).toBe(true);
-            expect((error as SfError).message).toContain(
-                util.format(
-                    messages.getMessage('error:invalidFlagValue'),
-                    'not-a-number'
-                )
-            );
-        }
     });
 
     test('Logger must be initialized and invoked', async () => {

--- a/src/common/IOSUtils.ts
+++ b/src/common/IOSUtils.ts
@@ -236,7 +236,8 @@ export class IOSUtils {
                         return false;
                     }
 
-                    return configuredRuntimeVersion.sameOrNewer(
+                    return Version.sameOrNewer(
+                        configuredRuntimeVersion,
                         minSupportedRuntimeIOS
                     );
                 }

--- a/src/common/__tests__/AndroidMockData.ts
+++ b/src/common/__tests__/AndroidMockData.ts
@@ -37,10 +37,7 @@ export class AndroidMockData {
     public static badMockRawPackagesString =
         'Installed packages:=====================]';
 
-    // NB: There are two codename packages in the output above, which should be
-    // ignored by parsing as of this release. This value represents an implicit
-    // test of discarding that data. The real count above is this value + 2.
-    public static mockRawStringPackageLength = 15;
+    public static mockRawStringPackageLength = 17;
 
     public static avdList = `
       Available Android Virtual Devices:

--- a/src/common/__tests__/AndroidUtils.test.ts
+++ b/src/common/__tests__/AndroidUtils.test.ts
@@ -263,7 +263,9 @@ describe('Android utils', () => {
         expect(apiPackage !== null && apiPackage.description !== null).toBe(
             true
         );
-        expect(apiPackage.version.same(Version.from(testAvdApi)!)).toBe(true);
+        expect(
+            Version.same(apiPackage.version, Version.from(testAvdApi)!)
+        ).toBe(true);
     });
 
     test('Should not find a preferred Android package', async () => {

--- a/src/common/__tests__/Common.test.ts
+++ b/src/common/__tests__/Common.test.ts
@@ -266,4 +266,36 @@ describe('Commons utils tests', () => {
             expect(common.Version.from(invalidVersion)).toBeNull();
         }
     });
+
+    test('compare versions', () => {
+        expect(
+            common.Version.same('1.2.3', common.Version.from('1.2.3')!)
+        ).toBe(true);
+
+        expect(
+            common.Version.sameOrNewer('1.2.3', common.Version.from('3.2.1')!)
+        ).toBe(false);
+
+        expect(common.Version.same('Tiramisu', 'Tiramisu')).toBe(true);
+
+        expect(common.Version.sameOrNewer('Tiramisu', 'Tiramisu')).toBe(true);
+
+        expect(
+            common.Version.sameOrNewer(
+                'Tiramisu',
+                common.Version.from('1.2.3')!
+            )
+        ).toBe(true);
+
+        expect(
+            common.Version.sameOrNewer(
+                common.Version.from('1.2.3')!,
+                'Tiramisu'
+            )
+        ).toBe(false);
+
+        expect(() => {
+            common.Version.sameOrNewer('Tiramisu', 'UpsideDownCake');
+        }).toThrow();
+    });
 });


### PR DESCRIPTION
Currently our commands (Device List, Device Create, Setup, ...) only work when targeting Android versions that follow proper semantic versioning. However when beta versions of Android are available they are often versioned as a codename (Tiramisu, UpsideDownCake, ...) which are strings not following proper semantic versioning.

This PR adds support for codename versions to our tools.