### PR TITLE
Add support for desktop as a platform

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,7 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "iOS - Setup",
+            "name": "Setup - iOS",
             "program": "${workspaceFolder}/bin/run",
             "args": [
                 "force:lightning:local:setup",
@@ -16,7 +16,7 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "Android - Setup",
+            "name": "Setup - Android",
             "program": "${workspaceFolder}/bin/run",
             "args": [
                 "force:lightning:local:setup",

--- a/messages/common.json
+++ b/messages/common.json
@@ -26,7 +26,8 @@
     "bootTimeOut": "Timeout waiting for %s to boot.",
     "powerOffTimeOut": "Timeout waiting for %s to power off.",
 
-    "platformFlagDescription": "Specify platform ('iOS' or 'Android').",
+    "platformFlagMobileOnlyDescription": "Specify platform ('iOS' or 'Android').",
+    "platformFlagIncludingDesktopDescription": "Specify platform ('Desktop' or 'iOS' or 'Android').",
     "apiLevelFlagDescription": "Specify Android API level. Defaults to the latest API level installed.",
     "jsonFlagDescription": "Format output as json.",
     "logLevelFlagDescription": "Logging level for this command invocation (options: TRACE, DEBUG, INFO, WARN, ERROR, FATAL).",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/lwc-dev-mobile-core",
   "description": "Core module supporting Salesforce CLI mobile extension plug-ins",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "author": {
     "name": "Meisam Seyed Aliroteh",
     "email": "maliroteh@salesforce.com",

--- a/src/common/CommonUtils.ts
+++ b/src/common/CommonUtils.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { Logger, LoggerLevelValue, SfError } from '@salesforce/core';
+import { Logger, LoggerLevelValue, Messages, SfError } from '@salesforce/core';
 import * as childProcess from 'child_process';
 import { ux } from '@oclif/core';
 import fs from 'fs';
@@ -17,6 +17,16 @@ import os from 'os';
 type StdioOptions = childProcess.StdioOptions;
 
 const LOGGER_NAME = 'force:lightning:local:commonutils';
+
+// Initialize Messages with the current plugin directory
+Messages.importMessagesDirectory(__dirname);
+
+// Load the specific messages for this file. Messages from @salesforce/command, @salesforce/core,
+// or any library that is using the messages framework can also be loaded this way.
+const messages = Messages.loadMessages(
+    '@salesforce/lwc-dev-mobile-core',
+    'common'
+);
 
 export class CommonUtils {
     public static DEFAULT_LWC_SERVER_PORT = '3333';
@@ -336,9 +346,14 @@ export class CommonUtils {
                 ? 'start'
                 : 'xdg-open';
 
-        return CommonUtils.executeCommandAsync(`${openCmd} ${url}`).then(() =>
-            Promise.resolve()
+        CommonUtils.startCliAction(
+            messages.getMessage('launchBrowserAction'),
+            util.format(messages.getMessage('openBrowserWithUrlStatus'), url)
         );
+        return CommonUtils.executeCommandAsync(`${openCmd} ${url}`).then(() => {
+            CommonUtils.stopCliAction();
+            return Promise.resolve();
+        });
     }
 
     /**

--- a/src/common/__tests__/Common.test.ts
+++ b/src/common/__tests__/Common.test.ts
@@ -152,7 +152,7 @@ describe('Commons utils tests', () => {
         );
         expect(platformFlagConfig.platform).toBeDefined();
         expect(platformFlagConfig.platform!.description).toBe(
-            messages.getMessage('platformFlagDescription')
+            messages.getMessage('platformFlagMobileOnlyDescription')
         );
         let requiredKeyValuePair = Object.entries(
             platformFlagConfig.platform!

--- a/src/common/__tests__/CommonUtils.test.ts
+++ b/src/common/__tests__/CommonUtils.test.ts
@@ -10,6 +10,11 @@ import fs from 'fs';
 import path from 'path';
 
 describe('CommonUtils', () => {
+    beforeEach(() => {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        jest.spyOn(CommonUtils, 'startCliAction').mockImplementation(() => {});
+    });
+
     test('replaceTokens function', async () => {
         const template =
             // tslint:disable-next-line:no-invalid-template-strings


### PR DESCRIPTION
Previously, plugin commands that are built on top of `lwc-dev-mobile-core` would only support `ios` or `android` as platforms. In this PR we add the ability for a plugin command to specify `desktop` as a platform as well.