### PR TITLE
chore: revising publish version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@salesforce/lwc-dev-mobile-core",
     "description": "Core module supporting Salesforce CLI mobile extension plug-ins",
-    "version": "4.1.0-alpha.0",
+    "version": "4.0.0-alpha.8",
     "author": {
         "name": "Meisam Seyed Aliroteh",
         "email": "maliroteh@salesforce.com",


### PR DESCRIPTION
### What does this PR do?
Bumps the version to `4.0.0.alpha.8`, prior to publish.
