### PR TITLE
chore: add baseline coverage

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,6 @@ jobs:
             - name: Upload coverage to Codecov
               uses: codecov/codecov-action@v5
               with:
-                  verbose: true
                   token: ${{ secrets.CODECOV_TOKEN }}
     run-tests-win:
         runs-on: windows-latest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,11 +16,10 @@ jobs:
             - run: yarn install
             - run: yarn test
             - name: Upload coverage to Codecov
-              uses: codecov/codecov-action@v4
+              uses: codecov/codecov-action@v5
               with:
+                  verbose: true
                   token: ${{ secrets.CODECOV_TOKEN }}
-                  files: coverage/*.json
-                  flags: frontend,backend
     run-tests-win:
         runs-on: windows-latest
         strategy:

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
         "postpack": "shx rm -f oclif.manifest.json oclif.lock",
         "prepack": "yarn clean-all && npm run sf-prepack",
         "sf-prepack": "sf-prepack",
-        "test": "c8 mocha 'test/unit/**/*.test.ts'",
+        "test": "c8 mocha 'test/unit/**/*.test.ts' && c8 report --reporter=lcov",
         "test:nuts": "nyc mocha \"**/*.nut.ts\" --slow 4500 --timeout 600000 --parallel",
         "test:only": "wireit",
         "version": "oclif readme"


### PR DESCRIPTION
### What does this PR do?
It seems like this [PR](https://github.com/forcedotcom/lwc-dev-mobile-core/commit/1296ed9b8f90ea8b146b4e23deafda1c631ac791) was the last commit that ever uploaded code coverage successfully. Since then many PRs have not been able to upload the coverage to codecov and hence losing the base coverage along the way. 

This PR is to re-establish the baseline again. Also, adding `lcov` as the report that produces `lcov.info` which is a code coverage reporting format.

Updating codecov github action to V5 as well.

