### PR TITLE
fix: terminate app before launching

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@salesforce/lwc-dev-mobile-core",
     "description": "Core module supporting Salesforce CLI mobile extension plug-ins",
-    "version": "4.0.0-alpha.10",
+    "version": "4.0.0-alpha.11",
     "author": {
         "name": "Meisam Seyed Aliroteh",
         "email": "maliroteh@salesforce.com",

--- a/test/unit/common/AndroidUtils.test.ts
+++ b/test/unit/common/AndroidUtils.test.ts
@@ -435,11 +435,12 @@ describe('Android utils', () => {
 
         const pathQuote = process.platform === 'win32' ? '"' : "'";
 
-        expect(stub.calledTwice);
+        expect(stub.calledThrice);
         expect(stub.firstCall.args[0]).to.equal(
             `${adbCommand} -s emulator-${port} install -r -t ${pathQuote}${appBundlePath.trim()}${pathQuote}`
         );
-        expect(stub.secondCall.args[0]).to.equal(
+        expect(stub.secondCall.args[0]).to.equal(`${adbCommand} -s emulator-${port} shell am force-stop ${targetApp}`);
+        expect(stub.thirdCall.args[0]).to.equal(
             `${adbCommand} -s emulator-${port}` +
                 ` shell am start -S -n "${targetApp}/${targetActivity}"` +
                 ' -a android.intent.action.MAIN' +


### PR DESCRIPTION
Similar to iOS platform, when attempting to launch an app on an Android emulator, we now first terminate the app (in case it is already running) and then relaunch it along with new launch arguments (if any) so that new launch arguments are picked up.