### PR TITLE
chore: add workflow for publishing to NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: publish
+run-name: Publish to NPM and Create Git Tag
+on:
+    workflow_dispatch:
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        environment:
+            name: npm-publish
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+
+            - name: Use Node.js
+              uses: actions/setup-node@v3
+              with:
+                  node-version: '20'
+
+            - name: Get package version
+              id: get-version
+              run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+            - name: Check if version is already published to NPM
+              run: |
+                  PUBLISHED=$(npm view $(node -p "require('./package.json').name") versions --json | grep -q "\"${{ steps.get-version.outputs.version }}\"" && echo "true" || echo "false")
+                  if [ "$PUBLISHED" = "true" ]; then
+                    echo "ERROR: Version ${{ steps.get-version.outputs.version }} is already published to NPM."
+                    exit 1
+                  fi
+
+            - name: Check if git tag exists
+              run: |
+                  if git rev-parse "v${{ steps.get-version.outputs.version }}" >/dev/null 2>&1; then
+                    echo "ERROR: Git tag v${{ steps.get-version.outputs.version }} already exists."
+                    exit 1
+                  fi
+
+            - name: Install dependencies
+              run: yarn install
+
+            - name: Publish to NPM
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+              run: npm publish
+
+            - name: Create and push git tag
+              run: |
+                  GIT_USER="${{ github.actor }}"
+                  GIT_EMAIL="${GIT_USER}@users.noreply.github.com"
+                  git config user.name "$GIT_USER"
+                  git config user.email "$GIT_EMAIL"
+                  git tag "v${{ steps.get-version.outputs.version }}"
+                  git push origin "v${{ steps.get-version.outputs.version }}"


### PR DESCRIPTION
Add a new workflow which can be manually triggered to publish a new version of the package to NPM.
