### PR TITLE
Running requirement checks headless

### DIFF
--- a/src/cli/commands/force/lightning/local/setup.ts
+++ b/src/cli/commands/force/lightning/local/setup.ts
@@ -10,7 +10,11 @@ import { BaseCommand } from '../../../../../common/BaseCommand.js';
 import { FlagsConfigType } from '../../../../../common/Common.js';
 import { CommandLineUtils } from '../../../../../common/CommandLineUtils.js';
 import { IOSEnvironmentRequirements } from '../../../../../common/IOSEnvironmentRequirements.js';
-import { CommandRequirements, RequirementProcessor } from '../../../../../common/Requirements.js';
+import {
+    CommandRequirements,
+    RequirementProcessor,
+    RequirementCheckResult
+} from '../../../../../common/Requirements.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/lwc-dev-mobile-core', 'setup');
@@ -29,7 +33,7 @@ export class Setup extends BaseCommand {
 
     protected _commandName = 'force:lightning:local:setup';
 
-    public async run(): Promise<void> {
+    public async run(): Promise<RequirementCheckResult> {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         this.logger.info(`Setup command called for ${this.flagValues.platform}`);
         return RequirementProcessor.execute(this.commandRequirements);

--- a/src/common/Requirements.ts
+++ b/src/common/Requirements.ts
@@ -150,24 +150,6 @@ export class RequirementProcessor {
                 totalDuration += result.duration;
             }
 
-            if (!headless) {
-                // Log summary in headless mode
-                const logger = new Logger('RequirementProcessor');
-                logger.info(
-                    `Requirements check completed in ${RequirementProcessor.formatDurationAsSeconds(totalDuration)}`
-                );
-                logger.info(`Passed: ${testResult.tests.filter((t) => t.hasPassed).length}/${testResult.tests.length}`);
-
-                for (const test of testResult.tests) {
-                    const status = test.hasPassed ? '✓' : '✗';
-                    const duration = RequirementProcessor.formatDurationAsSeconds(test.duration);
-                    logger.info(`${status} ${test.title} (${duration})`);
-                    if (!test.hasPassed && test.message) {
-                        logger.error(`  ${test.message}`);
-                    }
-                }
-            }
-
             // In headless mode, throw an error if requirements failed (same behavior as interactive mode)
             if (!testResult.hasMetAllRequirements) {
                 return Promise.reject(
@@ -249,6 +231,24 @@ export class RequirementProcessor {
                     messages.getMessage('error:requirementCheckFailed:recommendation')
                 ])
             );
+        }
+
+        if (!headless) {
+            // Log summary when NOT in headless mode (interactive mode)
+            const logger = new Logger('RequirementProcessor');
+            logger.info(
+                `Requirements check completed in ${RequirementProcessor.formatDurationAsSeconds(totalDuration)}`
+            );
+            logger.info(`Passed: ${testResult.tests.filter((t) => t.hasPassed).length}/${testResult.tests.length}`);
+
+            for (const test of testResult.tests) {
+                const status = test.hasPassed ? '✓' : '✗';
+                const duration = RequirementProcessor.formatDurationAsSeconds(test.duration);
+                logger.info(`${status} ${test.title} (${duration})`);
+                if (!test.hasPassed && test.message) {
+                    logger.error(`  ${test.message}`);
+                }
+            }
         }
 
         return testResult;


### PR DESCRIPTION
### What does this PR do?

Requirement checking depends on Listr which is a command line utility meant to format output nicely for cli consumption. Since we'd like to use core functionality in non cli environments (i.e. MCP) we need to be able to run the requirements in a headless fashion and report results programmatically rather than through stdout (which breaks MCP)
