### PR TITLE
feat: return device state for getting device list

### DIFF
--- a/src/common/device/AndroidDevice.ts
+++ b/src/common/device/AndroidDevice.ts
@@ -14,7 +14,7 @@ import { AndroidUtils } from '../AndroidUtils.js';
 import { Version } from '../Common.js';
 import { CryptoUtils, SSLCertificateData } from '../CryptoUtils.js';
 import { CommonUtils } from '../CommonUtils.js';
-import { BaseDevice, DeviceType, LaunchArgument } from './BaseDevice.js';
+import { BaseDevice, DeviceState, DeviceType, LaunchArgument } from './BaseDevice.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/lwc-dev-mobile-core', 'common');
@@ -42,7 +42,7 @@ export class AndroidDevice implements BaseDevice {
     public readonly osType: string;
     public readonly osVersion: string | Version;
     public readonly isPlayStore: boolean;
-
+    public readonly state: DeviceState;
     private port: number = -1;
 
     public constructor(
@@ -52,6 +52,7 @@ export class AndroidDevice implements BaseDevice {
         osType: string,
         osVersion: Version | string,
         isPlayStore: boolean,
+        state: DeviceState,
         logger?: Logger
     ) {
         this.id = id;
@@ -60,14 +61,15 @@ export class AndroidDevice implements BaseDevice {
         this.osType = osType;
         this.osVersion = osVersion;
         this.isPlayStore = isPlayStore;
+        this.state = state;
         this.logger = logger;
     }
 
     /**
-     * A string representation of an AppleDevice which includes Device Name, OS Type, and OS Version
+     * A string representation of an AppleDevice which includes Device Name, OS Type, OS Version and state
      */
     public toString(): string {
-        return `${this.name}, ${this.osType} ${this.osVersion.toString()}`;
+        return `${this.name}, ${this.osType} ${this.osVersion.toString()}, ${this.state}`;
     }
 
     public emulatorPort(): number {

--- a/src/common/device/AppleDevice.ts
+++ b/src/common/device/AppleDevice.ts
@@ -13,7 +13,7 @@ import { Version } from '../Common.js';
 import { CommonUtils } from '../CommonUtils.js';
 import { CryptoUtils, SSLCertificateData } from '../CryptoUtils.js';
 import { IOSUtils } from '../IOSUtils.js';
-import { BaseDevice, DeviceType, LaunchArgument } from './BaseDevice.js';
+import { BaseDevice, DeviceState, DeviceType, LaunchArgument } from './BaseDevice.js';
 
 export type AppleDeviceType = {
     bundlePath: string; // e.g: /Library/Developer/CoreSimulator/Profiles/DeviceTypes/iPhone 16 Pro.simdevicetype
@@ -52,6 +52,7 @@ export class AppleDevice implements BaseDevice {
     public readonly deviceType: DeviceType;
     public readonly osType: string;
     public readonly osVersion: string | Version;
+    public readonly state: DeviceState;
 
     public constructor(
         id: string,
@@ -59,6 +60,7 @@ export class AppleDevice implements BaseDevice {
         deviceType: DeviceType,
         osType: string,
         osVersion: Version,
+        state: DeviceState,
         logger?: Logger
     ) {
         this.id = id;
@@ -66,14 +68,15 @@ export class AppleDevice implements BaseDevice {
         this.deviceType = deviceType;
         this.osType = osType;
         this.osVersion = osVersion;
+        this.state = state;
         this.logger = logger;
     }
 
     /**
-     * A string representation of an AppleDevice which includes Device Name, OS Type, OS Version, and udid
+     * A string representation of an AppleDevice which includes Device Name, OS Type, OS Version, udid and state
      */
     public toString(): string {
-        return `${this.name}, ${this.osType} ${this.osVersion.toString()}, ${this.id}`;
+        return `${this.name}, ${this.osType} ${this.osVersion.toString()}, ${this.id}, ${this.state}`;
     }
 
     /**

--- a/src/common/device/AppleDeviceManager.ts
+++ b/src/common/device/AppleDeviceManager.ts
@@ -10,7 +10,7 @@ import { Version } from '../Common.js';
 import { CommonUtils } from '../CommonUtils.js';
 import { PlatformConfig } from '../PlatformConfig.js';
 import { AppleDevice, AppleOSType, AppleRuntime } from './AppleDevice.js';
-import { DeviceType } from './BaseDevice.js';
+import { DeviceState, DeviceType } from './BaseDevice.js';
 
 export class AppleDeviceManager {
     private logger?: Logger;
@@ -186,8 +186,20 @@ export class AppleDeviceManager {
 
                     const osVersion = Version.from(runtimeDefinition.version);
 
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                    const stateString = runtimeDevice.state as string;
+                    let state = DeviceState.Shutdown;
+                    switch (stateString) {
+                        case 'Booted':
+                            state = DeviceState.Booted;
+                            break;
+                        case 'Booting':
+                            state = DeviceState.Booting;
+                            break;
+                    }
+
                     if (id && name && osVersion) {
-                        results.push(new AppleDevice(id, name, deviceType, osType, osVersion, this.logger));
+                        results.push(new AppleDevice(id, name, deviceType, osType, osVersion, state, this.logger));
                     }
                 }
             }

--- a/src/common/device/BaseDevice.ts
+++ b/src/common/device/BaseDevice.ts
@@ -36,6 +36,7 @@ export type BaseDevice = {
     readonly deviceType: DeviceType;
     readonly osType: string;
     readonly osVersion: Version | string;
+    readonly state: DeviceState;
 
     toString(): string;
 
@@ -49,3 +50,15 @@ export type BaseDevice = {
     isCertInstalled(certData: SSLCertificateData): Promise<boolean>;
     installCert(certData: SSLCertificateData): Promise<void>;
 };
+
+/**
+ * The state of the device.
+ */
+export enum DeviceState {
+    // The simulator device is in the process of starting up
+    Booting = 'Booting',
+    // The simulator device is fully booted and ready to use
+    Booted = 'Booted',
+    // The simulator device is not running
+    Shutdown = 'Shutdown'
+}

--- a/test/unit/common/AndroidLauncher.test.ts
+++ b/test/unit/common/AndroidLauncher.test.ts
@@ -11,7 +11,7 @@ import { CommonUtils } from '../../../src/common/CommonUtils.js';
 import { AndroidLauncher } from '../../../src/common/AndroidLauncher.js';
 import { PreviewUtils } from '../../../src/common/PreviewUtils.js';
 import { AndroidDeviceManager } from '../../../src/common/device/AndroidDeviceManager.js';
-import { DeviceType } from '../../../src/common/device/BaseDevice.js';
+import { DeviceType, DeviceState } from '../../../src/common/device/BaseDevice.js';
 import { AndroidDevice, AndroidOSType } from '../../../src/common/device/AndroidDevice.js';
 import { Version } from '../../../src/common/Common.js';
 
@@ -25,7 +25,8 @@ describe('Android Launcher tests', () => {
         DeviceType.mobile,
         AndroidOSType.googleAPIs,
         new Version(31, 0, 0),
-        false
+        false,
+        DeviceState.Shutdown
     );
     const launcher = new AndroidLauncher(mockDevice.name);
 

--- a/test/unit/common/device/AndroidDevice.test.ts
+++ b/test/unit/common/device/AndroidDevice.test.ts
@@ -14,7 +14,7 @@ import { AndroidSDKRootSource, AndroidUtils } from '../../../../src/common/Andro
 import { CommonUtils } from '../../../../src/common/CommonUtils.js';
 import { AndroidMockData } from '../AndroidMockData.js';
 import { AndroidDevice, AndroidOSType, BootMode } from '../../../../src/common/device/AndroidDevice.js';
-import { DeviceType } from '../../../../src/common/device/BaseDevice.js';
+import { DeviceType, DeviceState } from '../../../../src/common/device/BaseDevice.js';
 import { Version } from '../../../../src/common/Common.js';
 
 describe('AndroidDevice', () => {
@@ -54,7 +54,8 @@ describe('AndroidDevice', () => {
                   DeviceType.mobile,
                   AndroidOSType.googleAPIs,
                   new Version(31, 0, 0),
-                  false
+                  false,
+                  DeviceState.Shutdown
               )
             : new AndroidDevice(
                   'Pixel_4_XL_API_29',
@@ -62,7 +63,8 @@ describe('AndroidDevice', () => {
                   DeviceType.mobile,
                   AndroidOSType.googleAPIs,
                   new Version(29, 0, 0),
-                  false
+                  false,
+                  DeviceState.Shutdown
               );
 
         stubMethod($$.SANDBOX, CommonUtils, 'delay').returns(Promise.resolve());
@@ -93,7 +95,8 @@ describe('AndroidDevice', () => {
             DeviceType.mobile,
             AndroidOSType.googleAPIs,
             new Version(28, 0, 0),
-            false
+            false,
+            DeviceState.Shutdown
         );
         await anotherMockDevice.boot();
         expect(anotherMockDevice.emulatorPort()).to.be.equal(5574);
@@ -119,5 +122,18 @@ describe('AndroidDevice', () => {
 
         await mockDevice.mountAsRootWritableSystem();
         expect(mockDevice.emulatorPort()).to.be.equal(5572);
+    });
+
+    it('toString should return the correct string', async () => {
+        const device = new AndroidDevice(
+            'Pixel_5_API_31',
+            'Pixel 5 API 31',
+            DeviceType.mobile,
+            AndroidOSType.googleAPIs,
+            new Version(31, 0, 0),
+            false,
+            DeviceState.Shutdown
+        );
+        expect(device.toString()).to.be.equal('Pixel 5 API 31, google apis 31.0.0, Shutdown');
     });
 });

--- a/test/unit/common/device/AppleDevice.test.ts
+++ b/test/unit/common/device/AppleDevice.test.ts
@@ -1,0 +1,18 @@
+import { expect } from 'chai';
+import { Version } from '../../../../src/common/Common.js';
+import { AppleDevice } from '../../../../src/common/device/AppleDevice.js';
+import { DeviceState, DeviceType } from '../../../../src/common/device/BaseDevice.js';
+
+describe('AppleDevice tests', () => {
+    it('toString should return the correct string', async () => {
+        const mockDevice = new AppleDevice(
+            '1234567890',
+            'iPhone 15 Pro',
+            DeviceType.mobile,
+            'iOS',
+            new Version(17, 0, 0),
+            DeviceState.Booted
+        );
+        expect(mockDevice.toString()).to.be.equal('iPhone 15 Pro, iOS 17.0.0, 1234567890, Booted');
+    });
+});

--- a/test/unit/common/device/AppleDeviceManager.test.ts
+++ b/test/unit/common/device/AppleDeviceManager.test.ts
@@ -11,6 +11,7 @@ import { CommonUtils } from '../../../../src/common/CommonUtils.js';
 import { AppleDeviceManager } from '../../../../src/common/device/AppleDeviceManager.js';
 import { AppleOSType } from '../../../../src/common/device/AppleDevice.js';
 import { Version } from '../../../../src/common/Common.js';
+import { DeviceState } from '../../../../src/common/device/BaseDevice.js';
 import { AppleMockData } from './AppleMockData.js';
 
 describe('AppleDeviceManager tests', () => {
@@ -68,6 +69,16 @@ describe('AppleDeviceManager tests', () => {
         stubMethod($$.SANDBOX, CommonUtils, 'executeCommandAsync').callsFake(myCommandRouterBlock);
         const results = await appleDeviceManager.enumerateDevices();
         expect(results.length === 4).to.be.true;
+
+        results.forEach((device) => {
+            let state = DeviceState.Shutdown;
+            if (device.id === '5D6ED992-29C3-43CC-8F94-3F8003B8494F') {
+                state = DeviceState.Booted;
+            } else if (device.id === '9826FDA1-7800-423C-9EC3-822FBF543C3B') {
+                state = DeviceState.Booting;
+            }
+            expect(device.state).to.be.equal(state);
+        });
     });
 
     it('Should enumerate devices using custom filtering', async () => {

--- a/test/unit/common/device/AppleMockData.ts
+++ b/test/unit/common/device/AppleMockData.ts
@@ -154,7 +154,7 @@ export class AppleMockData {
                     udid: '9826FDA1-7800-423C-9EC3-822FBF543C3B',
                     isAvailable: true,
                     deviceTypeIdentifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-15-Pro',
-                    state: 'Shutdown',
+                    state: 'Booting',
                     name: 'iPhone 15 Pro'
                 },
                 {
@@ -164,7 +164,7 @@ export class AppleMockData {
                     udid: '5D6ED992-29C3-43CC-8F94-3F8003B8494F',
                     isAvailable: true,
                     deviceTypeIdentifier: 'com.apple.CoreSimulator.SimDeviceType.iPad-Pro-13-inch-M4-8GB',
-                    state: 'Shutdown',
+                    state: 'Booted',
                     name: 'iPad Pro 13-inch (M4)'
                 }
             ],


### PR DESCRIPTION
### Currently the emulator or simulator running state is not returned when runs 
`sf force lightning local device list -p android`
`sf force lightning local device list -p ios`

Make it hard to see if which are running and have to call start device again and again.  
Adding the status could make the `sf force lightning local device *` more ergonomic to use. 
