### PR TITLE
fix: remove unused getAppBundlePath to eliminate arbitrary code execution

### DIFF
--- a/src/common/PreviewConfigFile.ts
+++ b/src/common/PreviewConfigFile.ts
@@ -29,8 +29,6 @@ class BaseAppPreviewConfig {
     public id!: string;
     public name!: string;
     // eslint-disable-next-line camelcase
-    public get_app_bundle?: string;
-    // eslint-disable-next-line camelcase
     public launch_arguments?: LaunchArgument[];
     // eslint-disable-next-line camelcase
     public preview_server_enabled?: boolean;

--- a/src/common/PreviewUtils.ts
+++ b/src/common/PreviewUtils.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import path from 'node:path';
-import { createRequire } from 'node:module';
 import Ajv from 'ajv';
 import { Logger } from '@salesforce/core';
 import { OSPlatform } from './Common.js';
@@ -105,28 +103,6 @@ export class PreviewUtils {
         const json = CommonUtils.loadJsonFromFile(file);
         const configFile = Object.assign(new PreviewConfigFile(), json);
         return configFile;
-    }
-
-    /**
-     * Attempts to obtain the app bundle path from an app preview config.
-     *
-     * @param basePath Path to the directory that contains the preview configuration file.
-     * @param appConfig An app preview configuration.
-     * @returns A string representing the app bundle path.
-     */
-    public static getAppBundlePath(
-        basePath: string,
-        appConfig: IOSAppPreviewConfig | AndroidAppPreviewConfig
-    ): string | undefined {
-        if (appConfig.get_app_bundle) {
-            const require = createRequire(import.meta.url);
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            const module = require(path.resolve(basePath, appConfig.get_app_bundle));
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-            return module.run();
-        } else {
-            return undefined;
-        }
     }
 
     /**

--- a/test/unit/common/PreviewMockConfigurationSchema.ts
+++ b/test/unit/common/PreviewMockConfigurationSchema.ts
@@ -40,10 +40,6 @@ export const mockSchema = `
           "type": "string",
           "description": "A friendly name describing the app."
         },
-        "get_app_bundle": {
-          "type": "string",
-          "description": "Module to get the app bundle to install. Executed from the directory of the configuration file."
-        },
         "launch_arguments": {
           "type": "array",
           "description": "Collection of additional name or name/value arguments to pass when launching the app.",

--- a/test/unit/common/PreviewUtils.test.ts
+++ b/test/unit/common/PreviewUtils.test.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { TestContext } from '@salesforce/core/testSetup';
 import { stubMethod } from '@salesforce/ts-sinon';
 import { expect } from 'chai';
@@ -169,19 +167,6 @@ describe('Preview utils tests', () => {
         const appConfig = configFile.getAppConfig('android', 'com.salesforce.Test') as AndroidAppPreviewConfig;
 
         expect(appConfig.activity).to.be.equal('.MyActivity');
-    });
-
-    it('Checks for obtaining app bundle path', async () => {
-        const iOSAppConfig = new IOSAppPreviewConfig();
-        iOSAppConfig.get_app_bundle = undefined;
-        expect(PreviewUtils.getAppBundlePath('', iOSAppConfig)).to.be.undefined;
-
-        iOSAppConfig.get_app_bundle = 'testGetAppBundleScript';
-        const bundlePath = PreviewUtils.getAppBundlePath(
-            path.dirname(path.resolve(fileURLToPath(import.meta.url))),
-            iOSAppConfig
-        );
-        expect(bundlePath).to.be.equal('sample/path/to/app/bundle');
     });
 
     it('Generates correct websocket url', async () => {

--- a/test/unit/common/testGetAppBundleScript
+++ b/test/unit/common/testGetAppBundleScript
@@ -1,3 +1,0 @@
-exports.run = function () {
-  return 'sample/path/to/app/bundle';
-};


### PR DESCRIPTION
## What

Removes `PreviewUtils.getAppBundlePath()` and the `get_app_bundle` preview-config field.

## Why

`getAppBundlePath()` resolved the `get_app_bundle` string from a preview configuration file, passed it to `require()`, and invoked the loaded module's `run()` export. Because `require()` executes a module's top-level code on load, any config able to set `get_app_bundle` to an attacker-controlled or path-traversing location could achieve **arbitrary code execution** on the developer's machine.

The method is **dead code** — it has no callers in this library and none in the downstream preview plugins, which stopped consuming it. Rather than harden a capability nothing uses, this removes it entirely.

## Changes

- Delete `getAppBundlePath` and its now-unused `node:path` / `node:module` imports
- Drop the `get_app_bundle` field from the preview app config type
- Remove the corresponding unit test, its fixture script, and the schema entry

If the compute-the-bundle-path capability is needed again, it should be reintroduced with a safe (non-executing) design.

## Testing

- `tsc` compile: clean
- Unit tests: **221 passing**, 2 pending
- ESLint + Prettier: clean